### PR TITLE
#9 PESM - added filtering for 'device' and 'deviceid'

### DIFF
--- a/include/rvs_util.h
+++ b/include/rvs_util.h
@@ -34,6 +34,9 @@ using std::string;
 extern vector<string> str_split(const string& str_val,
         const string& delimiter);
 
+extern int rvs_util_strarr_to_intarr(const std::vector<string>& sArr,
+                                     std::vector<int>* piArr);
+
 bool is_positive_integer(const std::string& str_val);
 
 #endif  // INCLUDE_RVS_UTIL_H_

--- a/pesm.so/include/action.h
+++ b/pesm.so/include/action.h
@@ -1,7 +1,29 @@
-
-
-#ifndef ACTION_H_
-#define ACTION_H_
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef PESM_SO_INCLUDE_ACTION_H_
+#define PESM_SO_INCLUDE_ACTION_H_
 
 #include "rvsactionbase.h"
 
@@ -15,16 +37,15 @@
  * in its run() method.
  *
  */
-class action : public rvs::actionbase
-{
-public:
+class action : public rvs::actionbase {
+ public:
   action();
   virtual ~action();
 
   virtual int run(void);
 
-protected:
+ protected:
   int do_gpu_list(void);
 };
 
-#endif /* ACTION_H_ */
+#endif  // PESM_SO_INCLUDE_ACTION_H_

--- a/pesm.so/include/worker.h
+++ b/pesm.so/include/worker.h
@@ -1,11 +1,36 @@
-
-#ifndef _WORKER_H_
-#define _WORKER_H_
+/********************************************************************************
+ *
+ * Copyright (c) 2018 ROCm Developer Tools
+ *
+ * MIT LICENSE:
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef PESM_SO_INCLUDE_WORKER_H_
+#define PESM_SO_INCLUDE_WORKER_H_
 
 #include <string>
+#include <vector>
+
 #include "rvsthreadbase.h"
 
-	
+
 /**
  * @class Worker
  * @ingroup PESM
@@ -18,35 +43,49 @@
  */
 
 class Worker : public rvs::ThreadBase {
+ public:
+  Worker();
+  ~Worker();
 
-public:
-	Worker();
-	~Worker();
-	
-	void stop(void);
+  void stop(void);
   //! Sets initiating action name
-	void set_name(const std::string& name) { action_name = name; }
-	//! sets stopping action name
-	void set_stop_name(const std::string& name) { stop_action_name = name; }
-	//! Sets JSON flag
-	void json(const bool flag) { bjson = flag; }
-	//! Returns initiating action name
-	const std::string& get_name(void) { return action_name; }
-	
-protected:
-	virtual void run(void);
-	
-protected:
+  void set_name(const std::string& name) { action_name = name; }
+  //! sets stopping action name
+  void set_stop_name(const std::string& name) { stop_action_name = name; }
+  //! Sets device id for filtering
+  void set_deviceid(const int id) { device_id = id; }
+  //! Sets GPU IDs for filtering
+  void set_gpuids(const std::vector<int>& GpuIds);
+  //! Sets GPU IDs for filtering (string used in messages)
+  //! @param Devices List of devices to monitor
+  void set_strgpuids(const std::string& Devices) { strgpuids = Devices; }
+  //! Sets JSON flag
+  void json(const bool flag) { bjson = flag; }
+  //! Returns initiating action name
+  const std::string& get_name(void) { return action_name; }
+
+ protected:
+  virtual void run(void);
+
+ protected:
   //! TRUE if JSON output is required
-	bool		bjson;
+  bool    bjson;
   //! Loops while TRUE
-	bool 		brun;
+  bool     brun;
+  //! device id to filter for. 0 if no filtering.
+  int device_id;
+  // GPU id filtering flag
+  bool bfiltergpu;
+  //! list of GPU devices to monitor
+  std::vector<int> gpuids;
+  //! list of GPU devices to monitor (string used in messages)
+  std::string strgpuids;
   //! Name of the action which initiated monitoring
-	std::string	action_name;
+  std::string  action_name;
   //! Name of the action which stops monitoring
-	std::string	stop_action_name;
+  std::string  stop_action_name;
 };
-	
 
 
-#endif // _WORKER_H_
+
+#endif  // PESM_SO_INCLUDE_WORKER_H_

--- a/pesm.so/src/action.cpp
+++ b/pesm.so/src/action.cpp
@@ -24,24 +24,30 @@
  *******************************************************************************/
 #include "action.h"
 
-#include "rvs_module.h"
-#include "worker.h"
-
-extern "C"
-{
+extern "C" {
 #include <pci/pci.h>
 #include <linux/pci.h>
 }
+
+#include <string>
+#include <vector>
+#include <map>
 #include <iostream>
 #include <algorithm>
 
+#include "rvs_module.h"
+#include "worker.h"
 #include "pci_caps.h"
 #include "gpu_util.h"
-#include "rvs_module.h"
+#include "rvs_util.h"
 #include "rvsloglp.h"
 
 
-using namespace std;
+using std::string;
+using std::cout;
+using std::cerr;
+using std::endl;
+using std::hex;
 
 extern const char* pcie_cap_names[];
 
@@ -61,9 +67,12 @@ action::~action() {
  *
  * Functionality:
  *
- * - If "do_gpu_list" property is set, it lists all AMD GPUs present in the system and exits
- * - If "monitor" property is set to "true", it creates Worker thread and initiates monitoring and exits
- * - If "monitor" property is not set or is not set to "true", it stops the Worker thread and exits
+ * - If "do_gpu_list" property is set,
+ *   it lists all AMD GPUs present in the system and exits
+ * - If "monitor" property is set to "true",
+ *   it creates Worker thread and initiates monitoring and exits
+ * - If "monitor" property is not set or is not set to "true",
+ *   it stops the Worker thread and exits
  *
  * @return 0 - success. non-zero otherwise
  *
@@ -71,38 +80,81 @@ action::~action() {
 int action::run(void) {
   log("[PESM] in run()", rvs::logdebug);
 
+  // debugging help
+  string val;
+  if (has_property("debugwait", val)) {
+    sleep(std::stoi(val));
+  }
+  // this module implements --listGpu command line option
+  // if this option is set, an internal input key 'do_gpu_list' is passed
+  // to this action
   if (has_property("do_gpu_list")) {
     return do_gpu_list();
   }
 
-  // handle "wait" property
-  if (property["wait"] != "") {
-    sleep(atoi(property["wait"].c_str()));
-  }
+  // start of monitoring?
+  if (property["monitor"] == "true") {
+    log("[PESM] property[\"monitor\"] == \"true\"", rvs::logdebug);
 
-  if(property["monitor"] == "true") {
-    log("property[\"monitor\"] == \"true\"", rvs::logdebug);
-
+    // create worker thread object
     if (!pworker) {
-    log("creating Worker", rvs::logdebug);
+    log("[PESM] creating Worker", rvs::logdebug);
       pworker = new Worker();
       pworker->set_name(property["name"]);
 
-      // pas -j flag
-      if( property.find("cli.-j") != property.end())
-      {
+      // check if  -j flag is passed
+      if (has_property("cli.-j")) {
         pworker->json(true);
       }
     }
-    log("starting Worker", rvs::logdebug);
+
+    // checki if deviceid filtering is required
+    string sdevid;
+    if (has_property("deviceid", sdevid)) {
+      if (::is_positive_integer(sdevid)) {
+        try {
+          pworker->set_deviceid(std::stoi(sdevid));
+        }
+        catch(...) {
+          cerr << "RVS-PESM: action: " << property["name"] <<
+          "  invalide 'deviceid' key value: " << sdevid << std::endl;
+          return -1;
+        }
+      } else {
+        cerr << "RVS-PESM: action: " << property["name"] <<
+        "  invalide 'deviceid' key value: " << sdevid << std::endl;
+        return -1;
+      }
+    }
+
+    // check if GPU id filtering is requied
+    string sdev;
+    if (has_property("device", sdev)) {
+      pworker->set_strgpuids(sdev);
+      if (sdev != "all") {
+        vector<string> sarr = str_split(sdev, YAML_DEVICE_PROP_DELIMITER);
+        vector<int> iarr;
+        int sts = rvs_util_strarr_to_intarr(sarr, &iarr);
+        if (sts < 0) {
+          cerr << "RVS-PESM: action: " << property["name"] <<
+          "  invalide 'device' key value: " << sdev << std::endl;
+          return -1;
+        }
+        pworker->set_gpuids(iarr);
+      }
+    } else {
+          cerr << "RVS-PESM: action: " << property["name"] <<
+          "  key 'device' not found" << std::endl;
+          return -1;
+    }
+
+    // start worker thread
+    log("[PESM] starting Worker", rvs::logdebug);
     pworker->start();
-//     log("detaching Worker", rvs::logdebug);
-//     pworker->detach();
 
     log("[PESM] Monitoring started", rvs::logdebug);
-  }
-  else {
-    log("property[\"monitor\"] != \"true\"", rvs::logdebug);
+  } else {
+    log("[PESM] property[\"monitor\"] != \"true\"", rvs::logdebug);
     if (pworker) {
       pworker->set_stop_name(property["name"]);
       pworker->stop();
@@ -127,36 +179,39 @@ int action::run(void) {
 int action::do_gpu_list() {
   log("[PESM] in do_gpu_list()", rvs::logdebug);
 
-  std::map<string,string>::iterator it;
-  std::vector<unsigned short int>   gpus_location_id;
+  std::map<string, string>::iterator it;
+  std::vector<unsigned short int> gpus_location_id;
 
   struct pci_access* pacc;
   struct pci_dev*    dev;
   char buff[1024];
   char devname[1024];
 
-  //get all GPU location_id (Note: we're not using device_id as the unique identifier
-  // because multiple GPUs can have the same ID. We use location_id which is unique and points to the sysfs
+  // get all GPU location_id
   gpu_get_all_location_id(gpus_location_id);
 
-  //get the pci_access structure
+  // get the pci_access structure
   pacc = pci_alloc();
-  //initialize the PCI library
+  // initialize the PCI library
   pci_init(pacc);
-  //get the list of devices
+  // get the list of devices
   pci_scan_bus(pacc);
 
   bool bheader_printed = false;
   int  ix = 0;
-  //iterate over devices
+  // iterate over devices
   for (dev = pacc->devices; dev; dev = dev->next) {
-    pci_fill_info(dev, PCI_FILL_IDENT | PCI_FILL_BASES | PCI_FILL_CLASS | PCI_FILL_EXT_CAPS | PCI_FILL_CAPS | PCI_FILL_PHYS_SLOT); //fil in the info
+    // fil in the info
+    pci_fill_info(dev, PCI_FILL_IDENT | PCI_FILL_BASES | PCI_FILL_CLASS
+    | PCI_FILL_EXT_CAPS | PCI_FILL_CAPS | PCI_FILL_PHYS_SLOT);
 
-    //computes the actual dev's location_id (sysfs entry)
-    unsigned short int dev_location_id = ((((unsigned short int)(dev->bus)) << 8) | (dev->func));
+    // computes the actual dev's location_id (sysfs entry)
+    unsigned short int dev_location_id =
+      ((((unsigned short int)(dev->bus)) << 8) | (dev->func));
 
-    //check if this pci_dev corresponds to one of AMD GPUs
-    auto it_gpu = find(gpus_location_id.begin(), gpus_location_id.end(), dev_location_id);
+    // check if this pci_dev corresponds to one of AMD GPUs
+    auto it_gpu = find(gpus_location_id.begin(), gpus_location_id.end(),
+                       dev_location_id);
 
     if (it_gpu == gpus_location_id.end())
       continue;
@@ -166,12 +221,14 @@ int action::do_gpu_list() {
       cout << "Supported GPUs available:" << endl;
     }
 
-    sprintf(buff, "%02X:%02X.%d", dev->bus, dev->dev, dev->func);
+    snprintf(buff, sizeof(buff), "%02X:%02X.%d", dev->bus, dev->dev, dev->func);
 
     string name;
-    name = pci_lookup_name(pacc, devname, sizeof(devname), PCI_LOOKUP_DEVICE, dev->vendor_id, dev->device_id);
+    name = pci_lookup_name(pacc, devname, sizeof(devname), PCI_LOOKUP_DEVICE,
+                           dev->vendor_id, dev->device_id);
 
-    cout << buff  << " - GPU[" << ix << "] " << name << hex << " (Device " << dev->device_id << ")"<< endl;
+    cout << buff  << " - GPU[" << ix << "] " << name << hex <<
+    " (Device " << dev->device_id << ")"<< endl;
     ix++;
   }
 

--- a/rvs/conf/pesm1.conf
+++ b/rvs/conf/pesm1.conf
@@ -1,0 +1,21 @@
+# PESM test #1
+#
+# Preconditions:
+#   Set device id to an existing AMD deviceid values
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/pesm2.conf
+#
+# Expected result:
+#   Test passes without displaying data for any GPUs
+actions:
+- name: act1 
+  device: all
+  deviceid: 26720
+  module: pesm
+  monitor: true
+- name: act2 
+  debugwait: 3000
+  module: pesm
+  monitor: false

--- a/rvs/conf/pesm2.conf
+++ b/rvs/conf/pesm2.conf
@@ -1,0 +1,23 @@
+# PESM test #2
+#
+# Preconditions:
+#   Set device id to arbitrary value different from actual AMD deviceid values
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/pesm2.conf
+#
+# Expected result:
+#   Test passes without displaying data for any GPUs
+
+actions:
+- name: act1 
+  device: all
+  deviceid: 50
+  module: pesm
+  monitor: true
+- name: act2 
+  device: all
+  deviceid: 50
+  module: pesm
+  monitor: false

--- a/rvs/conf/pesm3.conf
+++ b/rvs/conf/pesm3.conf
@@ -1,0 +1,23 @@
+# PESM test #3
+#
+# Preconditions:
+#   Set device to non-integer value
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/pesm3.conf
+#
+# Expected result:
+#   Test fails with an error message
+
+actions:
+- name: act1 
+  device: all
+  deviceid: xxx
+  module: pesm
+  monitor: true
+- name: act2 
+  device: all
+  deviceid: xxx
+  module: pesm
+  monitor: false

--- a/rvs/conf/pesm4.conf
+++ b/rvs/conf/pesm4.conf
@@ -1,0 +1,21 @@
+# PESM test #4
+#
+# Preconditions:
+#   Set device id to non-integer value
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/pesm4.conf
+#
+# Expected result:
+#   Test fails with an error message
+
+actions:
+- name: act1 
+  device: xxx
+  module: pesm
+  monitor: true
+- name: act2 
+  device: all
+  module: pesm
+  monitor: false

--- a/rvs/conf/pesm5.conf
+++ b/rvs/conf/pesm5.conf
@@ -1,0 +1,20 @@
+# PESM test #5
+#
+# Preconditions:
+#   Set device to an existing AMD device value
+#
+# Run test with:
+#   cd bin
+#   sudo ./rvs -c conf/pesm2.conf
+#
+# Expected result:
+#   Test passes while displaying data for the listed GPUs
+actions:
+- name: act1 
+  device: 1536 8960
+  module: pesm
+  monitor: true
+- name: act2 
+  debugwait: 3000
+  module: pesm
+  monitor: false

--- a/src/rvs_util.cpp
+++ b/src/rvs_util.cpp
@@ -52,6 +52,36 @@ vector<string> str_split(const string& str_val, const string& delimiter) {
     return str_tokens;
 }
 
+
+/**
+ * Conert array of strings into array of integers
+ * @param sArr input string
+ * @param iArr tokens' delimiter
+ * @return -1 if error, 0 <= otherwise
+ */
+int rvs_util_strarr_to_intarr(const std::vector<string>& sArr,
+                              std::vector<int>* piArr) {
+  int ssize = sArr.size();
+
+  piArr->clear();
+
+  for (auto it = sArr.begin(); it != sArr.end(); ++it) {
+    try {
+      if (is_positive_integer(*it)) {
+        piArr->push_back(std::stoi(*it));
+      }
+    }
+    catch(...) {
+    }
+  }
+
+  if (sArr.size() != piArr->size())
+    return -1;
+
+  return piArr->size();
+}
+
+
 /**
  * checks if input string is a positive integer number
  * @param str_val the input string


### PR DESCRIPTION
Relates to issue #9 

Run all tests using:
`sudo ./rvs -c conf/pesmxxx.conf -d 3`

where `pesmxxx` is pesm1 - pesm5
