### PR TITLE
Iss34

### DIFF
--- a/rvs/src/rvsexec.cpp
+++ b/rvs/src/rvsexec.cpp
@@ -4,7 +4,7 @@
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
- * this software and associated documentation fiiostreamles (the "Software"), to deal in
+ * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
  * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
  * of the Software, and to permit persons to whom the Software is furnished to do


### PR DESCRIPTION
#34 - Added implementation for -h option.

_Note: lines 163 - 195 are intentionally left over 80 columns because of the formatting nature of the output._

Test: `./rvs -h`