### PR TITLE
Iss62 - PEQT - Power Budgeting changes

### DIFF
--- a/include/pci_caps.h
+++ b/include/pci_caps.h
@@ -40,8 +40,8 @@ void get_device_id(struct pci_dev *dev, char *buff);
 void get_dev_serial_num(struct pci_dev *dev, char *buff);
 void get_vendor_id(struct pci_dev *dev, char *buff);
 void get_kernel_driver(struct pci_dev *dev, char *buff);
-void get_pwr_base_pwr(struct pci_dev *dev, char *buff);
-void get_pwr_rail_type(struct pci_dev *dev, char *buff);
+void get_pwr_budgeting(struct pci_dev *dev, uint8_t pb_pm_state,
+                       uint8_t pb_type, uint8_t pb_power_rail, char *buff);
 void get_pwr_curr_state(struct pci_dev *dev, char *buff);
 void get_atomic_op_routing(struct pci_dev *dev, char *buff);
 void get_atomic_op_32_completer(struct pci_dev *dev, char *buff);

--- a/peqt.so/include/action.h
+++ b/peqt.so/include/action.h
@@ -35,11 +35,15 @@ extern "C" {
 
 #include <vector>
 #include <string>
+#include <regex>
+#include <map>
 
 #include "rvsactionbase.h"
 
 using std::vector;
 using std::string;
+using std::regex;
+using std::map;
 
 /**
  * @class action
@@ -59,10 +63,20 @@ class action: public rvs::actionbase {
     virtual int run(void);
 
  private:
-
+    //! TRUE if JSON output is required
     bool bjson;
     //! JSON root node
     void* json_root_node;
+
+    //! PCI PB (Power Budgeting) <<PM State, encoding>> pairs (according to
+    //! PCI_Express_Base_Specification_Revision_3.0)
+    map <string, uint8_t> pb_op_pm_states_encodings_map;
+    //! PCI PB (Power Budgeting) <<Type, encoding>> pairs
+    map <string, uint8_t> pb_op_pm_types_encodings_map;
+    //! PCI PB (Power Budgeting) <<Power Rail, encoding>> pairs
+    map <string, uint8_t> pb_op_pm_power_rails_encodings_map;
+    //! regex for dynamic PB capabilities
+    regex pb_dynamic_regex;
 
     bool get_gpu_all_pcie_capabilities(struct pci_dev *dev, uint16_t gpu_id);
 

--- a/peqt.so/src/rvs_module.cpp
+++ b/peqt.so/src/rvs_module.cpp
@@ -25,6 +25,7 @@
 #include "rvs_module.h"
 #include "action.h"
 #include "rvsloglp.h"
+#include "gpu_util.h"
 
 /**
  * @defgroup PEQT PEQT Module
@@ -75,7 +76,8 @@ extern "C" const char* rvs_module_get_output(void) {
 
 extern "C" int rvs_module_init(void* pMi) {
     rvs::lp::Initialize(static_cast<T_MODULE_INIT*>(pMi));
-        return 0;
+    rvs::gpulist::Initialize();
+    return 0;
 }
 
 extern "C" int rvs_module_terminate(void) {

--- a/rvs/conf/peqt1.conf
+++ b/rvs/conf/peqt1.conf
@@ -21,8 +21,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V: 
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V: 
+    D0_Sustained_Power_3_3V: 
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt10.conf
+++ b/rvs/conf/peqt10.conf
@@ -25,8 +25,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt11.conf
+++ b/rvs/conf/peqt11.conf
@@ -27,8 +27,6 @@ actions:
     vendor_id: 
     kernel_driver: ^amdgpu$
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt12.conf
+++ b/rvs/conf/peqt12.conf
@@ -27,8 +27,10 @@ actions:
     vendor_id: 
     kernel_driver: ^amdgpu$
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt13.conf
+++ b/rvs/conf/peqt13.conf
@@ -22,7 +22,6 @@ actions:
     link_stat_cur_speed: '^(8 GT\/s)$'
     vendor_id: 
     kernel_driver: ^amdgpu$
-    pwr_rail_type:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt14.conf
+++ b/rvs/conf/peqt14.conf
@@ -34,8 +34,10 @@ actions:
     vendor_id: 
     kernel_driver: ^amdgpu$
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt15.conf
+++ b/rvs/conf/peqt15.conf
@@ -36,8 +36,10 @@ actions:
     vendor_id: 
     kernel_driver: ^amdgpu$
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: ^((TRUE|FALSE){1})$
     atomic_op_32_completer: ^((TRUE|FALSE){1})$
     atomic_op_64_completer: ^((TRUE|FALSE){1})$

--- a/rvs/conf/peqt3.conf
+++ b/rvs/conf/peqt3.conf
@@ -21,8 +21,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt4.conf
+++ b/rvs/conf/peqt4.conf
@@ -22,8 +22,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt5.conf
+++ b/rvs/conf/peqt5.conf
@@ -23,8 +23,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt6.conf
+++ b/rvs/conf/peqt6.conf
@@ -18,8 +18,6 @@ actions:
     link_stat_cur_speed: 
     link_stat_neg_width: 
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt7.conf
+++ b/rvs/conf/peqt7.conf
@@ -22,8 +22,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt8.conf
+++ b/rvs/conf/peqt8.conf
@@ -25,8 +25,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 

--- a/rvs/conf/peqt9.conf
+++ b/rvs/conf/peqt9.conf
@@ -27,8 +27,10 @@ actions:
     vendor_id: 
     kernel_driver:
     dev_serial_num:  
-    pwr_base_pwr: 
-    pwr_rail_type:
+    D0_Maximum_Power_12V:
+    D0_Maximum_Power_3_3V:
+    D0_Sustained_Power_12V:
+    D0_Sustained_Power_3_3V:
     atomic_op_routing: 
     atomic_op_32_completer: 
     atomic_op_64_completer: 


### PR DESCRIPTION
- changes summary
changed Power Budgeting as discussed & agreed in the last meeting with the customer
PB capability is now a dynamic one and can be any combination of PM State/Type/Power Rail 
`PMState = D0/D1/D2/D3`
`Type = PMEAux/Auxiliary/Idle/Sustained/Maximum`
`PowerRail =  Power_12V/Power_3_3V/Power_1_5V_1_8V/Thermal`
Valid combinations are in the form of  `<PMState>_<Type>_<PowerRail>`
E.g.: 
`D0_Auxiliary_Power_12V`
`D0_Sustained_Power_3_3V`

- how to run
`sudo bin/rvs -c bin/conf/peqtXX.conf -d 3`
where XX=1..17

- notice
Power Budgeting capabilities are not included/reported for the GPUs we're working with
I had to run tests on my Linux machine 
