### PR TITLE
Use LD_LIBRARY_PATH for Address Sanitizer.

### DIFF
--- a/babel.so/CMakeLists.txt
+++ b/babel.so/CMakeLists.txt
@@ -82,6 +82,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## Include common cmake modules

--- a/gm.so/CMakeLists.txt
+++ b/gm.so/CMakeLists.txt
@@ -113,6 +113,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 if(DEFINED RVS_ROCMSMI)

--- a/gpup.so/CMakeLists.txt
+++ b/gpup.so/CMakeLists.txt
@@ -113,6 +113,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## define include directories

--- a/gst.so/CMakeLists.txt
+++ b/gst.so/CMakeLists.txt
@@ -112,6 +112,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 # Determine Roc Runtime header files are accessible

--- a/iet.so/CMakeLists.txt
+++ b/iet.so/CMakeLists.txt
@@ -117,6 +117,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 # Determine Roc Runtime header files are accessible

--- a/mem.so/CMakeLists.txt
+++ b/mem.so/CMakeLists.txt
@@ -83,6 +83,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## Include common cmake modules

--- a/pebb.so/CMakeLists.txt
+++ b/pebb.so/CMakeLists.txt
@@ -130,6 +130,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 # Determine Roc Runtime header files are accessible

--- a/peqt.so/CMakeLists.txt
+++ b/peqt.so/CMakeLists.txt
@@ -111,6 +111,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## define include directories

--- a/perf.so/CMakeLists.txt
+++ b/perf.so/CMakeLists.txt
@@ -112,6 +112,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 # Determine Roc Runtime header files are accessible

--- a/pesm.so/CMakeLists.txt
+++ b/pesm.so/CMakeLists.txt
@@ -111,6 +111,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## define include directories

--- a/pqt.so/CMakeLists.txt
+++ b/pqt.so/CMakeLists.txt
@@ -129,6 +129,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 # Determine Roc Runtime header files are accessible

--- a/rcqt.so/CMakeLists.txt
+++ b/rcqt.so/CMakeLists.txt
@@ -113,6 +113,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## define include directories

--- a/rvs/CMakeLists.txt
+++ b/rvs/CMakeLists.txt
@@ -116,6 +116,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## define include directories

--- a/rvslib/CMakeLists.txt
+++ b/rvslib/CMakeLists.txt
@@ -114,6 +114,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## define include directories

--- a/smqt.so/CMakeLists.txt
+++ b/smqt.so/CMakeLists.txt
@@ -110,6 +110,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 ## define include directories

--- a/testif.so/CMakeLists.txt
+++ b/testif.so/CMakeLists.txt
@@ -111,6 +111,8 @@ if(BUILD_ADDRESS_SANITIZER)
   execute_process(COMMAND ${CMAKE_CXX_COMPILER} --print-file-name=libclang_rt.asan-x86_64.so
             OUTPUT_VARIABLE ASAN_LIB_FULL_PATH)
   get_filename_component(ASAN_LIB_PATH ${ASAN_LIB_FULL_PATH} DIRECTORY)
+else()
+  set(ASAN_LIB_PATH "$ENV{LD_LIBRARY_PATH}")
 endif()
 
 


### PR DESCRIPTION
Use LD_LIBRARY_PATH environment variable for Address Sanitizer library path.

SWDEV-306314
[ROCm Feature Address Sanitizer Support] ROCmValidationSuite in Mathlib seems unable to honor the variables