### PR TITLE
Standardize documentation for ReadtheDocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,12 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/docs/.sphinx" # Location of package manifests
+    directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
     labels:
+      - "m-DOC"
       - "dependencies"
     reviewers:
       - "samjwu"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/.sphinx/requirements.txt
+   - requirements: docs/sphinx/requirements.txt
 
 build:
    os: ubuntu-22.04

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,0 @@
-rocm-docs-core>=0.20.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,10 +4,31 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import re
+import subprocess
+
 from rocm_docs import ROCmDocs
 
-docs_core = ROCmDocs("RVS Documentation")
+with open('../CMakeLists.txt', encoding='utf-8') as f:
+    match = re.search(r'.*\bset \( RVS_VERSION\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    if not match:
+        raise ValueError("VERSION not found!")
+    version_number = match[1]
+left_nav_title = f"RVS {version_number} Documentation"
+
+# for PDF output on Read the Docs
+project = "RVS Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
+
+external_toc_path = "./sphinx/_toc.yml"
+
+docs_core = ROCmDocs(left_nav_title)
 docs_core.setup()
+
+external_projects_current_project = "rocmvalidationsuite"
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,4 @@
+# License
+
+```{include} ../LICENSE
+```

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -9,3 +9,6 @@ subtrees:
     - file: prerequisites
     - file: cli
     - file: regression
+  - caption: About
+    entries:
+    - file: license

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,1 @@
+rocm-docs-core==0.28.0

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -46,6 +46,10 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
+importlib-metadata==6.8.0
+    # via sphinx
+importlib-resources==6.1.1
+    # via rocm-docs-core
 jinja2==3.1.2
     # via
     #   myst-parser
@@ -83,6 +87,8 @@ pyjwt[crypto]==2.6.0
     # via pygithub
 pynacl==1.5.0
     # via pygithub
+pytz==2023.3.post1
+    # via babel
 pyyaml==6.0
     # via
     #   myst-parser
@@ -92,7 +98,7 @@ requests==2.31.0
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core>=0.20.0
+rocm-docs-core==0.28.0
     # via -r requirements.in
 smmap==5.0.0
     # via gitdb
@@ -139,3 +145,7 @@ urllib3==1.26.15
     # via requests
 wrapt==1.15.0
     # via deprecated
+zipp==3.17.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources


### PR DESCRIPTION
Relates to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330

Apply the following to repo docs:

add version number to documentation left navigation bar and page title
add an "About" section with a license page
enable htmlzip, pdf, epub formats when publishing on Read the Docs
set pdf title, author, copyright, and version
rename .sphinx/.doxygen to sphinx/doxygen
remove docBin from URL
update rocm-docs-core dependency
update dependabot config