### PR TITLE
Using domain field in getting PCIe id

### DIFF
--- a/iet.so/src/action.cpp
+++ b/iet.so/src/action.cpp
@@ -413,8 +413,9 @@ void iet_action::hip_to_smi_indices(void) {
 
         // compute device location_id (needed to match this device
         // with one of those found while querying the pci bus
-        uint16_t hip_dev_location_id =
-            ((((uint16_t) (props.pciBusID)) << 8) | (((uint16_t)(props.pciDeviceID)) << 3) );
+        uint64_t hip_dev_location_id = ( ( ((uint64_t)props.pciDomainID & 0xffff ) << 32) |
+            (((uint64_t) props.pciBusID & 0xff ) << 8) | (((uint64_t)props.pciDeviceID & 0x1f ) << 3) );
+
         if(smi_map.find(hip_dev_location_id) != smi_map.end()){
             hip_to_smi_idxs.insert({i, smi_map[hip_dev_location_id]});
         }


### PR DESCRIPTION
    BDF gives common number unless we use domain too to enumerate PCIe
    devices, which resulted in sending GEMM to one GPU and smi query to
    another. Hence using D:B:D value as uint 64, following smi conventions