### PR TITLE
SWDEV-444683 - Use the api provided by rocm-core to get ROCm install path rather than using hard coded paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,8 @@ set(HIP_INC_DIR "${ROCM_PATH}" CACHE PATH "Contains header files exported by ROC
 set(ROCT_INC_DIR "${ROCM_PATH}/include" CACHE PATH "Contains header files exported by ROC Trunk" FORCE)
 
 add_definitions(-DROCM_PATH="${ROCM_PATH}")
-add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/rvs")
+# The absolute library path will be ${ROCM_PATH}/${RVS_LIB_PATH}
+add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_LIBDIR}/rvs")
 
 #
 # If the user specifies -DCMAKE_BUILD_TYPE on the command line, take their
@@ -148,12 +149,12 @@ set(CPACK_PACKAGE_CONTACT "ROCM Validation Suite Support <rocm-validation-suite.
 
 # Package dependencies
 if (${RVS_OS_TYPE} STREQUAL "ubuntu")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, libpci3, libyaml-cpp-dev")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, libpci3, libyaml-cpp-dev")
 elseif (${RVS_OS_TYPE} STREQUAL "sles")
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, libpci3, libyaml-cpp0_6")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, libpci3, libyaml-cpp0_6")
 else ()
 # other supported rpm distros - RHEL, CentOS
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, pciutils-libs, yaml-cpp")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, pciutils-libs, yaml-cpp")
 endif()
 
 set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
@@ -465,6 +466,10 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 
 set(HCC_CXX_FLAGS "-fno-gpu-rdc --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx803 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx1101 --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942")
+
+# rocm-core library will provide the ROCM_PATH during runtime
+# Link the library as required
+set(ROCM_CORE "rocm-core")
 
 add_subdirectory(rvslib)
 add_subdirectory(rvs)

--- a/gm.so/tests.cmake
+++ b/gm.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES}
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES}
 )
 
 # Add directories to look for library files to link

--- a/gpup.so/tests.cmake
+++ b/gpup.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS libpthread.so libm.so libdl.so ${ROCM_SMI_LIB}
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES})
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES})
 
 # Add directories to look for library files to link
 link_directories(${RVS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR})

--- a/pesm.so/tests.cmake
+++ b/pesm.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES}
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES}
 )
 
 # Add directories to look for library files to link

--- a/rvs/CMakeLists.txt
+++ b/rvs/CMakeLists.txt
@@ -127,7 +127,7 @@ set(PROJECT_LINK_LIBS libdl.so libpthread.so libpci.so ${YAML_CPP_LIBRARIES})
 ## define target
 add_executable(${RVS_TARGET} src/rvs.cpp)
 target_link_libraries(${RVS_TARGET} rvslib
-  ${ROCBLAS_LIB} ${ROCM_SMI_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${PROJECT_LINK_LIBS})
+  ${ROCBLAS_LIB} ${ROCM_SMI_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${PROJECT_LINK_LIBS})
 add_dependencies(${RVS_TARGET} rvslib)
 
 install(TARGETS ${RVS_TARGET}

--- a/rvs/src/rvsexec.cpp
+++ b/rvs/src/rvsexec.cpp
@@ -38,6 +38,7 @@
 #include "include/rvsliblogger.h"
 #include "include/rvsoptions.h"
 #include "include/rvstrace.h"
+#include "rocm-core/rocm_getpath.h"
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -255,7 +256,21 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
   string  module;
   string config;
   yaml_data_type_t data_type;
-
+  char *installPath = nullptr;
+  unsigned int installPathLen = 0;
+  string rocmPath;
+  PathErrors_t retVal = PathSuccess;
+  // Get ROCM install path
+  retVal = getROCmInstallPath( &installPath, &installPathLen );
+  if(retVal == PathSuccess){
+    rocmPath = installPath;
+  }else {
+    std::cout << "Failed to get ROCm Install Path: " << retVal << std::endl;
+  }
+  // free allocated memory
+  if(installPath != nullptr) {
+    free(installPath);
+  }
   options::has_option("pwd", &path);
   logger::log_level(rvs::logerror);
 
@@ -264,7 +279,7 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
   }
   else if (rvs::options::has_option(opt, "module", &module)) {
 
-#define RVS_MODULE_MAX 11 
+#define RVS_MODULE_MAX 11
     std::map <std::string, int> module_map = {
       {"babel", 0},
       {"gpup", 1},
@@ -294,9 +309,9 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
     };
 
     auto itr = module_map.find(module);
-    int module_index = itr->second; 
+    int module_index = itr->second;
 
-    if(RVS_MODULE_MAX <= module_index) { 
+    if(RVS_MODULE_MAX <= module_index) {
       return -1;
     }
 
@@ -308,7 +323,7 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
       std::ifstream file(path + config);
       if (!file.good()) {
         // configuration file exist in ROCM path ?
-        path = ROCM_PATH;
+        path = rocmPath;
         config = "/share/rocm-validation-suite/conf/" + module_config_file[module_index];
       }
       file.close();
@@ -346,7 +361,7 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
     std::ifstream conf_file(val);
     if (!conf_file.good()) {
       // Modules config. file exist in ROCM path ?
-      path = ROCM_PATH;
+      path = rocmPath;
       val = path + "/share/rocm-validation-suite/conf/.rvsmodules.config";
     }
   }

--- a/rvs/src/rvsexec.cpp
+++ b/rvs/src/rvsexec.cpp
@@ -265,7 +265,7 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
   if(retVal == PathSuccess){
     rocmPath = installPath;
   }else {
-    std::cout << "Failed to get ROCm Install Path: " << retVal << std::endl;
+    std::cout << "Failed to get ROCm Install Path: " << retVal <<"\nSet ROCM_PATH in env" << std::endl;
   }
   // free allocated memory
   if(installPath != nullptr) {

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -191,7 +191,7 @@ rvs::module* rvs::module::find_create_module(const char* name) {
         if(retVal == PathSuccess){
           rocmPath = installPath;
         }else {
-          std::cout << "Failed to get ROCm Install Path: " << retVal << std::endl;
+          std::cout << "Failed to get ROCm Install Path: " << retVal <<"\nSet ROCM_PATH in env" << std::endl;
         }
         // free allocated memory
         if(installPath != nullptr) {

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -40,6 +40,7 @@
 #include "include/rvsaction.h"
 #include "include/rvsliblog.h"
 #include "include/rvsoptions.h"
+#include "rocm-core/rocm_getpath.h"
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -181,7 +182,23 @@ rvs::module* rvs::module::find_create_module(const char* name) {
       // error?
       if (!psolib) {
         //Search libraries in RVS install path
-        libpath = RVS_LIB_PATH;
+        char *installPath = nullptr;
+        unsigned int installPathLen = 0;
+        string rocmPath;
+        PathErrors_t retVal = PathSuccess;
+        // Get the ROCm install path
+        retVal = getROCmInstallPath( &installPath, &installPathLen );
+        if(retVal == PathSuccess){
+          rocmPath = installPath;
+        }else {
+          std::cout << "Failed to get ROCm Install Path: " << retVal << std::endl;
+        }
+        // free allocated memory
+        if(installPath != nullptr) {
+          free(installPath);
+        }
+        libpath = rocmPath;
+        libpath += RVS_LIB_PATH;
         libpath += "/";
         string sofullname(libpath + it->second);
         psolib = dlopen(sofullname.c_str(), RTLD_NOW);

--- a/rvs/tests.cmake
+++ b/rvs/tests.cmake
@@ -210,7 +210,7 @@ FOREACH(SINGLE_TEST ${TESTSOURCES})
     ${PROJECT_LINK_LIBS}
     ${PROJECT_TEST_LINK_LIBS}
     rvslib rvslibut gtest_main gtest pthread
-    ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET}
+    ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE}
   )
   add_dependencies(${TEST_NAME} rvs_gtest_target)
 

--- a/smqt.so/tests.cmake
+++ b/smqt.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES}
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES}
 )
 
 # Add directories to look for library files to link


### PR DESCRIPTION
RVS library librvslib.so was having hard coded paths, since hard coded strings provided by build scripts were used to get ROCM_PATH. Use the api provided by rocm-core for getting the same. Also added package dependency to rocm-core