### PR TITLE
MI300A specific pebb conf. file

### DIFF
--- a/pbqt.so/src/action.cpp
+++ b/pbqt.so/src/action.cpp
@@ -243,7 +243,7 @@ bool pbqt_action::get_all_pbqt_config_keys(void) {
   if( link_type == 2) {
       link_type_string = "PCIe";
   }
-  else if(link_type == 3) {
+  else if(link_type == 4) {
       link_type_string = "XGMI";
   }
 

--- a/pebb.so/src/action.cpp
+++ b/pebb.so/src/action.cpp
@@ -120,7 +120,7 @@ bool pebb_action::get_all_pebb_config_keys(void) {;
   }
   if( link_type == 2)
     link_type_string = "PCIe";
-  else if(link_type == 3)
+  else if(link_type == 4)
     link_type_string = "XGMI";
 
   return bsts;

--- a/rvs/conf/MI300A/pebb_single.conf
+++ b/rvs/conf/MI300A/pebb_single.conf
@@ -1,6 +1,6 @@
 # ################################################################################
 # #
-# # Copyright (c) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
+# # Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
 # #
 # # MIT LICENSE:
 # # Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -32,10 +32,8 @@
 #
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test1.conf -d 3
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
 #
-
-
 actions:
 - name: h2d-sequential-51MB
   device: all
@@ -46,7 +44,7 @@ actions:
   host_to_device: true
   parallel: true
   block_size: 51200000
-  link_type: 2 # PCIe
+  link_type: 4 # XGMI 
 
 
 # PEBB test #2
@@ -58,10 +56,8 @@ actions:
 #
 # Run test with :
 #   cd bin
-#   ./rvs -c conf/pebb_test2.conf -d 3
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
 #
-
-
 - name: d2h-sequential-51MB
   device: all
   module: pebb
@@ -71,8 +67,7 @@ actions:
   host_to_device: true
   parallel: true
   block_size: 51200000
-  link_type: 2 # PCIe
-
+  link_type: 4 # XGMI 
 
 
 # PEBB test #3
@@ -84,9 +79,8 @@ actions:
 #
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test3.conf -d 3
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
 #
-
 - name: h2d-d2h-sequential-51MB
   device: all
   module: pebb
@@ -96,9 +90,7 @@ actions:
   host_to_device: true
   parallel: true
   block_size: 51200000
-  link_type: 2 # PCIe
-
-
+  link_type: 4 # XGMI 
 
 
 # PEBB test #4
@@ -110,8 +102,8 @@ actions:
 # 5. random block sizes
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test4.conf -d 3
-
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
+#
 - name: h2d-parallel-xMB
   device: all
   module: pebb
@@ -120,7 +112,7 @@ actions:
   device_to_host: true
   host_to_device: true
   parallel: true
-  link_type: 2 # PCIe
+  link_type: 4 # XGMI 
 
 
 # PEBB test #5
@@ -132,8 +124,8 @@ actions:
 # 5. random block sizes
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test5.conf -d 3
-
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
+#
 - name: d2h-parallel-xMB
   device: all
   module: pebb
@@ -142,8 +134,7 @@ actions:
   device_to_host: true
   host_to_device: true
   parallel: true
-  link_type: 2 # PCIe
-
+  link_type: 4 # XGMI 
 
 
 # PEBB test #6
@@ -155,8 +146,8 @@ actions:
 # 5. random block sizes
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test6.conf -d 3
-
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
+#
 - name: h2d-d2h-xMB
   device: all
   module: pebb
@@ -165,7 +156,7 @@ actions:
   device_to_host: true
   host_to_device: true
   parallel: true
-  link_type: 2 # PCIe
+  link_type: 4 # XGMI 
 
 
 # PEBB test #7
@@ -177,8 +168,8 @@ actions:
 # 5. back-to-back 51MB
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test7.conf -d 3
-
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
+#
 - name: h2d-b2b-51MB
   device: all
   module: pebb
@@ -188,7 +179,7 @@ actions:
   host_to_device: true
   b2b_block_size: 51200
   parallel: false
-  link_type: 2  # PCIe
+  link_type: 4 # XGMI 
 
 
 # PEBB test #8
@@ -200,8 +191,8 @@ actions:
 # 5. back-to-back 51MB
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test8.conf -d 3
-
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
+#
 - name: d2h-b2b-51MB
   device: all
   module: pebb
@@ -211,19 +202,20 @@ actions:
   host_to_device: true
   b2b_block_size: 51200
   parallel: true
-  link_type: 2  # PCIe
+  link_type: 4 # XGMI 
+
 
 # PEBB test #9
 # testing conditions:
 # 1. all AMD compatible GPUs
 # 2. all types of devices
 # 3. bidirectional
-# 4. PCIe ponly
+# 4. XGMI only
 # 5. parallel back-to-back transfers
 # Run test with:
 #   cd bin
-#   ./rvs -c conf/pebb_test9.conf -d 3
-
+#   ./rvs -c conf/MI300A/pebb_single.conf -d 3
+#
 - name: h2d-d2h-b2b-51MB
   device: all
   module: pebb
@@ -233,4 +225,5 @@ actions:
   host_to_device: true
   b2b_block_size: 51200
   parallel: false
-  link_type: 2  # PCIe
+  link_type: 4 # XGMI
+ 


### PR DESCRIPTION
- Corrected the value of XGMI link type
- dos2unix on default pebb file
