### PR TITLE
handle cases where version >= in dependency

### DIFF
--- a/rcqt.so/src/packageHandler.cpp
+++ b/rcqt.so/src/packageHandler.cpp
@@ -28,6 +28,17 @@
 #include <iostream>
 #include "include/packageHandler.h"
 
+
+// expected versions usually either = or >=. 
+bool isVersionMismatch(std::string expected, std::string installed){
+  if(expected.find("+") == std::string::npos){
+    return expected.compare(installed) != 0;
+  }
+  expected = expected.substr(0, expected.size()-1);
+  auto exp = std::stof(expected);
+  auto ins = std::stof(installed);
+  return ins < exp;
+}
 bool PackageHandler::parseManifest(){
 
   if(m_manifest.empty()) {
@@ -77,7 +88,7 @@ void PackageHandler::validatePackages(){
 			continue;
 		}
 
-		if( inputversion.compare(installedvers)){
+		if(isVersionMismatch(inputversion, installedvers)){
 			++badVersions;
 			std::cout << "Error: version mismatch for package " << inputname <<
 					" expected version: " << inputversion << " but installed " <<

--- a/rcqt.so/src/zypPackageInfo.cpp
+++ b/rcqt.so/src/zypPackageInfo.cpp
@@ -35,7 +35,7 @@ bool ZypPackageInfo::readMetaPackageInfo(std::string ss){
   bool found = false;
   size_t pos = std::string::npos;
   std::ofstream os;
-
+  std::string greaterVers{};
   os.open(getFileName() , std::ofstream::out | std::ofstream::app);
 
   while(std::getline(inss, line)){
@@ -49,7 +49,9 @@ bool ZypPackageInfo::readMetaPackageInfo(std::string ss){
         pos = line.find("=");
 
         if(std::string::npos != pos){
-
+        size_t gpos = line.find(">=");
+	if(std::string::npos != gpos && gpos == pos-1)
+		greaterVers = "+"; 
           /* Get dependent package and its version */
 
           size_t firstCharPos = line.find_first_not_of(" ");
@@ -63,6 +65,8 @@ bool ZypPackageInfo::readMetaPackageInfo(std::string ss){
 	  if (std::string::npos != p)
           	depPackageVersion = depPackageVersion.substr(0, p);
           /* Write dependent package name and its version to file */
+	  depPackageVersion+=greaterVers;
+	  greaterVers.erase();
           os << depPackageName << " " << depPackageVersion << std::endl;
 
           pos = std::string::npos;


### PR DESCRIPTION
dependency if shown as >= was failing in cases when installed is not equal to dependency. Fixed it