### PR TITLE
Provide an option to fetch ROCm install path using the api provided by rocm-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,11 @@ if ( ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   message(FATAL "In-source build is not allowed")
 endif ()
 enable_testing()
+# In future use the api provided by rocm-core library to get ROCm Install path
+# For backward compatibility use ROCM_PATH provided by build arguments.
+# Using the api option is turned OFF by default
+option(FETCH_ROCMPATH_FROM_ROCMCORE
+        "Use the api provided by rocm-core library to get ROCM_PATH" OFF)
 
 # Prerequisite - Check if rocblas was already installed
 find_package (rocblas)
@@ -79,9 +84,19 @@ set(HIP_INC_DIR "${ROCM_PATH}" CACHE PATH "Contains header files exported by ROC
 set(ROCT_INC_DIR "${ROCM_PATH}/include" CACHE PATH "Contains header files exported by ROC Trunk" FORCE)
 
 add_definitions(-DROCM_PATH="${ROCM_PATH}")
-# The absolute library path will be ${ROCM_PATH}/${RVS_LIB_PATH}
-add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_LIBDIR}/rvs")
-
+if(FETCH_ROCMPATH_FROM_ROCMCORE)
+  add_compile_options(-DFETCH_ROCMPATH_FROM_ROCMCORE=${FETCH_ROCMPATH_FROM_ROCMCORE})
+  # rocm-core library will provide the ROCM_PATH during runtime
+  # Link the library as required
+  set(ROCM_CORE "rocm-core")
+  # The absolute library path will be ${ROCM_PATH}/${RVS_LIB_PATH}
+  # Usage is ROCM_PATH will be fetched from rocm-core and append ${RVS_LIB_PATH}
+  add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_LIBDIR}/rvs")
+else()
+  add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/rvs")
+  # Set ROCM_CORE to empty, so no linking to rocm-core library/package
+  set(ROCM_CORE "")
+endif()
 #
 # If the user specifies -DCMAKE_BUILD_TYPE on the command line, take their
 # definition and dump it in the cache along with proper documentation,
@@ -149,12 +164,12 @@ set(CPACK_PACKAGE_CONTACT "ROCM Validation Suite Support <rocm-validation-suite.
 
 # Package dependencies
 if (${RVS_OS_TYPE} STREQUAL "ubuntu")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, libpci3, libyaml-cpp-dev")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, ${ROCM_CORE}, libpci3, libyaml-cpp-dev")
 elseif (${RVS_OS_TYPE} STREQUAL "sles")
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, libpci3, libyaml-cpp0_6")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, ${ROCM_CORE}, libpci3, libyaml-cpp0_6")
 else ()
 # other supported rpm distros - RHEL, CentOS
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, pciutils-libs, yaml-cpp")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, ${ROCM_CORE}, pciutils-libs, yaml-cpp")
 endif()
 
 set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
@@ -466,10 +481,6 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 
 set(HCC_CXX_FLAGS "-fno-gpu-rdc --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx803 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx1101 --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942")
-
-# rocm-core library will provide the ROCM_PATH during runtime
-# Link the library as required
-set(ROCM_CORE "rocm-core")
 
 add_subdirectory(rvslib)
 add_subdirectory(rvs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,8 @@ set(HIP_INC_DIR "${ROCM_PATH}" CACHE PATH "Contains header files exported by ROC
 set(ROCT_INC_DIR "${ROCM_PATH}/include" CACHE PATH "Contains header files exported by ROC Trunk" FORCE)
 
 add_definitions(-DROCM_PATH="${ROCM_PATH}")
-add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/rvs")
+# The absolute library path will be ${ROCM_PATH}/${RVS_LIB_PATH}
+add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_LIBDIR}/rvs")
 
 #
 # If the user specifies -DCMAKE_BUILD_TYPE on the command line, take their
@@ -148,12 +149,12 @@ set(CPACK_PACKAGE_CONTACT "ROCM Validation Suite Support <rocm-validation-suite.
 
 # Package dependencies
 if (${RVS_OS_TYPE} STREQUAL "ubuntu")
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, libpci3, libyaml-cpp-dev")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, libpci3, libyaml-cpp-dev")
 elseif (${RVS_OS_TYPE} STREQUAL "sles")
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, libpci3, libyaml-cpp0_6")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, libpci3, libyaml-cpp0_6")
 else ()
 # other supported rpm distros - RHEL, CentOS
-set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, pciutils-libs, yaml-cpp")
+set(CPACK_RPM_PACKAGE_REQUIRES "hip-runtime-amd, comgr, hsa-rocr, rocblas, rocm-smi-lib, rocm-core, pciutils-libs, yaml-cpp")
 endif()
 
 set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
@@ -465,6 +466,10 @@ if(BUILD_ADDRESS_SANITIZER)
 endif()
 
 set(HCC_CXX_FLAGS "-fno-gpu-rdc --offload-arch=gfx90a --offload-arch=gfx1030 --offload-arch=gfx803 --offload-arch=gfx900 --offload-arch=gfx906 --offload-arch=gfx908 --offload-arch=gfx1101 --offload-arch=gfx940 --offload-arch=gfx941 --offload-arch=gfx942")
+
+# rocm-core library will provide the ROCM_PATH during runtime
+# Link the library as required
+set(ROCM_CORE "rocm-core")
 
 add_subdirectory(rvslib)
 add_subdirectory(rvs)

--- a/gm.so/tests.cmake
+++ b/gm.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES}
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES}
 )
 
 # Add directories to look for library files to link

--- a/gpup.so/tests.cmake
+++ b/gpup.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS libpthread.so libm.so libdl.so ${ROCM_SMI_LIB}
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES})
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES})
 
 # Add directories to look for library files to link
 link_directories(${RVS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ROCT_LIB_DIR} ${ROCBLAS_LIB_DIR})

--- a/pesm.so/tests.cmake
+++ b/pesm.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES}
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES}
 )
 
 # Add directories to look for library files to link

--- a/rvs/CMakeLists.txt
+++ b/rvs/CMakeLists.txt
@@ -127,7 +127,7 @@ set(PROJECT_LINK_LIBS libdl.so libpthread.so libpci.so ${YAML_CPP_LIBRARIES})
 ## define target
 add_executable(${RVS_TARGET} src/rvs.cpp)
 target_link_libraries(${RVS_TARGET} rvslib
-  ${ROCBLAS_LIB} ${ROCM_SMI_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${PROJECT_LINK_LIBS})
+  ${ROCBLAS_LIB} ${ROCM_SMI_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${PROJECT_LINK_LIBS})
 add_dependencies(${RVS_TARGET} rvslib)
 
 install(TARGETS ${RVS_TARGET}

--- a/rvs/src/rvsexec.cpp
+++ b/rvs/src/rvsexec.cpp
@@ -38,7 +38,9 @@
 #include "include/rvsliblogger.h"
 #include "include/rvsoptions.h"
 #include "include/rvstrace.h"
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
 #include "rocm-core/rocm_getpath.h"
+#endif
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -256,6 +258,7 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
   string  module;
   string config;
   yaml_data_type_t data_type;
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
   char *installPath = nullptr;
   unsigned int installPathLen = 0;
   string rocmPath;
@@ -264,13 +267,15 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
   retVal = getROCmInstallPath( &installPath, &installPathLen );
   if(retVal == PathSuccess){
     rocmPath = installPath;
-  }else {
+  }
+  else {
     std::cout << "Failed to get ROCm Install Path: " << retVal <<"\nSet ROCM_PATH in env" << std::endl;
   }
   // free allocated memory
   if(installPath != nullptr) {
     free(installPath);
   }
+#endif
   options::has_option("pwd", &path);
   logger::log_level(rvs::logerror);
 
@@ -323,7 +328,11 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
       std::ifstream file(path + config);
       if (!file.good()) {
         // configuration file exist in ROCM path ?
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
         path = rocmPath;
+#else
+        path = ROCM_PATH;
+#endif
         config = "/share/rocm-validation-suite/conf/" + module_config_file[module_index];
       }
       file.close();
@@ -361,7 +370,11 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
     std::ifstream conf_file(val);
     if (!conf_file.good()) {
       // Modules config. file exist in ROCM path ?
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
       path = rocmPath;
+#else
+      path = ROCM_PATH;
+#endif
       val = path + "/share/rocm-validation-suite/conf/.rvsmodules.config";
     }
   }

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -40,6 +40,7 @@
 #include "include/rvsaction.h"
 #include "include/rvsliblog.h"
 #include "include/rvsoptions.h"
+#include "rocm-core/rocm_getpath.h"
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -181,7 +182,23 @@ rvs::module* rvs::module::find_create_module(const char* name) {
       // error?
       if (!psolib) {
         //Search libraries in RVS install path
-        libpath = RVS_LIB_PATH;
+        char *installPath = nullptr;
+        unsigned int installPathLen = 0;
+        string rocmPath;
+        PathErrors_t retVal = PathSuccess;
+        // Get the ROCm install path
+        retVal = getROCmInstallPath( &installPath, &installPathLen );
+        if(retVal == PathSuccess){
+          rocmPath = installPath;
+        }else {
+          std::cout << "Failed to get ROCm Install Path: " << retVal <<"\nSet ROCM_PATH in env" << std::endl;
+        }
+        // free allocated memory
+        if(installPath != nullptr) {
+          free(installPath);
+        }
+        libpath = rocmPath;
+        libpath += RVS_LIB_PATH;
         libpath += "/";
         string sofullname(libpath + it->second);
         psolib = dlopen(sofullname.c_str(), RTLD_NOW);

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -40,7 +40,9 @@
 #include "include/rvsaction.h"
 #include "include/rvsliblog.h"
 #include "include/rvsoptions.h"
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
 #include "rocm-core/rocm_getpath.h"
+#endif
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -182,6 +184,7 @@ rvs::module* rvs::module::find_create_module(const char* name) {
       // error?
       if (!psolib) {
         //Search libraries in RVS install path
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
         char *installPath = nullptr;
         unsigned int installPathLen = 0;
         string rocmPath;
@@ -190,7 +193,8 @@ rvs::module* rvs::module::find_create_module(const char* name) {
         retVal = getROCmInstallPath( &installPath, &installPathLen );
         if(retVal == PathSuccess){
           rocmPath = installPath;
-        }else {
+        }
+        else {
           std::cout << "Failed to get ROCm Install Path: " << retVal <<"\nSet ROCM_PATH in env" << std::endl;
         }
         // free allocated memory
@@ -198,7 +202,11 @@ rvs::module* rvs::module::find_create_module(const char* name) {
           free(installPath);
         }
         libpath = rocmPath;
+        libpath += "/";
         libpath += RVS_LIB_PATH;
+#else
+        libpath = RVS_LIB_PATH;
+#endif
         libpath += "/";
         string sofullname(libpath + it->second);
         psolib = dlopen(sofullname.c_str(), RTLD_NOW);

--- a/rvs/tests.cmake
+++ b/rvs/tests.cmake
@@ -41,7 +41,7 @@ link_directories(${RVS_LIB_DIR} ${ROCBLAS_LIB_DIR} ${ROCM_SMI_LIB_DIR} ${ROCT_LI
 ## define target for "test-to-fail"
 add_executable(${RVS_TARGET}fail src/rvs.cpp)
 target_link_libraries(${RVS_TARGET}fail rvslib rvslibut ${PROJECT_LINK_LIBS}
-  ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET})
+  ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${ROCM_CORE} ${CORE_RUNTIME_TARGET})
 
 target_compile_definitions(${RVS_TARGET}fail PRIVATE RVS_INVERT_RETURN_STATUS)
 set_target_properties(${RVS_TARGET}fail PROPERTIES

--- a/rvs/tests.cmake
+++ b/rvs/tests.cmake
@@ -210,7 +210,7 @@ FOREACH(SINGLE_TEST ${TESTSOURCES})
     ${PROJECT_LINK_LIBS}
     ${PROJECT_TEST_LINK_LIBS}
     rvslib rvslibut gtest_main gtest pthread
-    ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET}
+    ${ROCM_SMI_LIB} ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE}
   )
   add_dependencies(${TEST_NAME} rvs_gtest_target)
 

--- a/smqt.so/tests.cmake
+++ b/smqt.so/tests.cmake
@@ -29,7 +29,7 @@ set(CORE_RUNTIME_NAME "hsa-runtime")
 set(CORE_RUNTIME_TARGET "${CORE_RUNTIME_NAME}64")
 
 set(UT_LINK_LIBS  libpthread.so libpci.so libm.so libdl.so "lib${ROCM_SMI_LIB}.so"
-  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${YAML_CPP_LIBRARIES}
+  ${ROCBLAS_LIB} ${ROC_THUNK_NAME} ${CORE_RUNTIME_TARGET} ${ROCM_CORE} ${YAML_CPP_LIBRARIES}
 )
 
 # Add directories to look for library files to link


### PR DESCRIPTION
By default use the existing way of getting ROCM_PATH from build arguments.  This will help in backward compatibility. 
Build scripts can enable the compile time option, so that api provided by rocm-core can be used to fetch ROCm Install path.
