### PR TITLE
brun not explicitly set

### DIFF
--- a/include/rvstimer.h
+++ b/include/rvstimer.h
@@ -59,8 +59,10 @@ class timer : public ThreadBase {
  *
  */
   timer(timerfunc_t cbFunc, T* cbArg) {
+
     cbfunc = cbFunc;
     cbarg = cbArg;
+    brun = false; // enable it when starting the thread
   }
 
   //! Default destructor


### PR DESCRIPTION
In many runs,first instance of timer is set to non zero value resulting in avreage logging function not run.