### PR TITLE
gpup run need not stop at individual error

### DIFF
--- a/gpup.so/src/action.cpp
+++ b/gpup.so/src/action.cpp
@@ -467,11 +467,6 @@ int gpup_action::run(void) {
       sts = property_get_value(*it);
       sts = property_io_links_get_value(*it);
       // so far so good?
-      if (sts == 0) {
-        RVSTRACE_
-        // do io_links properties
-        //sts = property_io_links_get_value(*it);
-      }
 
       if (bjson) {  // json logging stuff
         RVSTRACE_
@@ -481,7 +476,6 @@ int gpup_action::run(void) {
 
       if (sts) {
         RVSTRACE_
-        //break;
       }
     }  // for all gpu_id
 

--- a/gpup.so/src/action.cpp
+++ b/gpup.so/src/action.cpp
@@ -49,6 +49,7 @@
 #define JSON_PROP_NODE_NAME             "properties"
 #define JSON_IO_LINK_PROP_NODE_NAME     "io_links-properties"
 #define JSON_CREATE_NODE_ERROR          "JSON cannot create node"
+#define JSON_ROOT_NODE_ERROR            "JSON NULL root node"
 
 #define CHAR_MAX_BUFF_SIZE              256
 
@@ -172,6 +173,8 @@ int gpup_action::property_get_value(uint16_t gpu_id) {
     RVSTRACE_
     if (json_root_node == NULL) {
       RVSTRACE_
+      msg = std::string(JSON_ROOT_NODE_ERROR);
+      rvs::lp::Err(msg, MODULE_NAME_CAPS, action_name);
       return -1;
     }
     json_gpuprop_node = rvs::lp::CreateNode(json_root_node,
@@ -462,12 +465,12 @@ int gpup_action::run(void) {
 
       // properties values
       sts = property_get_value(*it);
-
+      sts = property_io_links_get_value(*it);
       // so far so good?
       if (sts == 0) {
         RVSTRACE_
         // do io_links properties
-        sts = property_io_links_get_value(*it);
+        //sts = property_io_links_get_value(*it);
       }
 
       if (bjson) {  // json logging stuff
@@ -478,7 +481,7 @@ int gpup_action::run(void) {
 
       if (sts) {
         RVSTRACE_
-        break;
+        //break;
       }
     }  // for all gpu_id
 


### PR DESCRIPTION
for some GPUs if said properties are absent, we should report it and move on to next property instead of prematurely abandoning the rest of the flow.