### PR TITLE
Update changelog and documentation configuration/requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,34 +2,41 @@
 
 Full documentation for RVS is available at [ROCmValidationSuite.Readme](https://github.com/ROCm-Developer-Tools/ROCmValidationSuite).
 
-## (Unreleased) RVS for ROCm 6.1
+## RVS 1.0.0 for ROCm 6.1
 
 ### Changed
+
 - Updated pebb & pbqt logs to include PCI BDF.
 
 ### Added
+
 - Support data types (BF16 and FP8) based GEMM operations in GPU Stress Test (GST) module.
 
-## RVS for ROCm 6.0
+## RVS 1.0.0 for ROCm 6.0
 
 ### Added
+
 - Support for Mariner OS
 - Support for gfx941 & gfx942
 - Navi31 and Navi32 specific configurations
 - GST stress test support for MI300X
 
-## RVS for ROCm 5.7
+## RVS 1.0.0 for ROCm 5.7
 
 ### Added
+
 - Introduced new RVS interface APIs enabling test execution from external components.
 - Added new "device_index" property for conf. file.
 
 ### Changed
+
 - Moved all static internal libraries to a single public shared library (rvslib).
 - Use HIP stream callback mechanism for gemm operations completion (instead of polling).
 
 ### Optimizations
+
 - In GST and IET modules, use of callback mechanism instead of polling for HIP stream reduced the CPU utilization %.
 
 ### Removed
+
 - yaml-cpp source download and build removed from RVS cmake build.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,6 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import re
-import subprocess
 
 from rocm_docs import ROCmDocs
 
@@ -19,16 +18,13 @@ left_nav_title = f"RVS {version_number} Documentation"
 # for PDF output on Read the Docs
 project = "RVS Documentation"
 author = "Advanced Micro Devices, Inc."
-copyright = "Copyright (c) 2023 Advanced Micro Devices, Inc. All rights reserved."
+copyright = "Copyright (c) 2023-2024 Advanced Micro Devices, Inc. All rights reserved."
 version = version_number
 release = version_number
 
-external_toc_path = "./sphinx/_toc.yml"
-
-docs_core = ROCmDocs(left_nav_title)
-docs_core.setup()
-
+html_title = left_nav_title
+extensions = ["rocm_docs"]
+html_theme = "rocm_docs_theme"
+html_theme_options = {"flavor": "rocm"}
 external_projects_current_project = "rocmvalidationsuite"
-
-for sphinx_var in ROCmDocs.SPHINX_VARS:
-    globals()[sphinx_var] = getattr(docs_core, sphinx_var)
+external_toc_path = "./sphinx/_toc.yml"

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -16,7 +16,7 @@ beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
 breathe==4.35.0
     # via rocm-docs-core
-certifi==2024.2.2
+certifi==2024.7.4
     # via requests
 cffi==1.16.0
     # via
@@ -26,7 +26,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via sphinx-external-toc
-cryptography==42.0.7
+cryptography==42.0.8
     # via pyjwt
 deprecated==1.2.14
     # via pygithub
@@ -36,7 +36,7 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
-fastjsonschema==2.19.1
+fastjsonschema==2.20.0
     # via rocm-docs-core
 gitdb==4.0.11
     # via gitpython
@@ -62,13 +62,13 @@ mdurl==0.1.2
     # via markdown-it-py
 myst-parser==3.0.1
     # via rocm-docs-core
-packaging==24.0
+packaging==24.1
     # via
     #   pydata-sphinx-theme
     #   sphinx
 pycparser==2.22
     # via cffi
-pydata-sphinx-theme==0.15.2
+pydata-sphinx-theme==0.15.4
     # via
     #   rocm-docs-core
     #   sphinx-book-theme
@@ -88,7 +88,7 @@ pyyaml==6.0.1
     #   myst-parser
     #   rocm-docs-core
     #   sphinx-external-toc
-requests==2.32.2
+requests==2.32.3
     # via
     #   pygithub
     #   sphinx
@@ -100,7 +100,7 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==7.3.7
+sphinx==7.4.5
     # via
     #   breathe
     #   myst-parser
@@ -111,15 +111,15 @@ sphinx==7.3.7
     #   sphinx-design
     #   sphinx-external-toc
     #   sphinx-notfound-page
-sphinx-book-theme==1.1.2
+sphinx-book-theme==1.1.3
     # via rocm-docs-core
 sphinx-copybutton==0.5.2
     # via rocm-docs-core
-sphinx-design==0.5.0
+sphinx-design==0.6.0
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
     # via rocm-docs-core
-sphinx-notfound-page==1.0.1
+sphinx-notfound-page==1.0.2
     # via rocm-docs-core
 sphinxcontrib-applehelp==1.0.8
     # via sphinx
@@ -135,11 +135,11 @@ sphinxcontrib-serializinghtml==1.1.10
     # via sphinx
 tomli==2.0.1
     # via sphinx
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   pydata-sphinx-theme
     #   pygithub
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   pygithub
     #   requests


### PR DESCRIPTION
Updates changelog to include RVS version 1.0.0 for ROCm 5.7, 6.0, 6.1
Updates minor documentation requirements
Uses rocm-docs-core as an extension instead of calling it directly in conf.py

Closes https://github.com/ROCm/ROCm/issues/3428