### PR TITLE
Fix Read the Docs build error due to missing version

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,13 +6,12 @@
 
 import re
 
-from rocm_docs import ROCmDocs
-
 with open('../CMakeLists.txt', encoding='utf-8') as f:
-    match = re.search(r'.*\bset \( RVS_VERSION\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    match = re.search(r'project\s*\(.*VERSION\s+([0-9.]+)\)', f.read(), re.DOTALL)
     if not match:
         raise ValueError("VERSION not found!")
     version_number = match[1]
+
 left_nav_title = f"RVS {version_number} Documentation"
 
 # for PDF output on Read the Docs


### PR DESCRIPTION
Fix documentation build failure due to "VERSION not found!" due to https://github.com/ROCm/ROCmValidationSuite/commit/bd38a86c56bab80d43b176fb837aa103a9582c1f