### PR TITLE
Mem json cleanup

### DIFF
--- a/mem.so/src/rvs_memworker.cpp
+++ b/mem.so/src/rvs_memworker.cpp
@@ -163,6 +163,7 @@ void MemWorker::run() {
     size_t          free;
     size_t          total;
     int             deviceId;
+    bool info_jsonlogs = false;  
 
     // log MEM stress test - start message
     msg = "[" + action_name + "] " + MODULE_NAME + " " +
@@ -198,7 +199,7 @@ void MemWorker::run() {
             std::to_string(total) + " " + " Free Memory from hipMemGetInfo " + " " + 
             std::to_string(free);
     rvs::lp::Log(msg, rvs::logtrace);
-    if (bjson){
+    if (bjson && info_jsonlogs){
 	void *json_node = json_node_create(std::string(MODULE_NAME),
       		action_name.c_str(), rvs::loginfo);
 	if (json_node){

--- a/mem.so/src/rvs_memworker.cpp
+++ b/mem.so/src/rvs_memworker.cpp
@@ -163,7 +163,7 @@ void MemWorker::run() {
     size_t          free;
     size_t          total;
     int             deviceId;
-   
+    bool info_jsonlogs = false;  
 
     // log MEM stress test - start message
     msg = "[" + action_name + "] " + MODULE_NAME + " " +
@@ -199,7 +199,7 @@ void MemWorker::run() {
             std::to_string(total) + " " + " Free Memory from hipMemGetInfo " + " " + 
             std::to_string(free);
     rvs::lp::Log(msg, rvs::logtrace);
-    if (bjson){
+    if (bjson && info_jsonlogs){
 	void *json_node = json_node_create(std::string(MODULE_NAME),
       		action_name.c_str(), rvs::loginfo);
 	if (json_node){
@@ -211,7 +211,7 @@ void MemWorker::run() {
 
 		rvs::lp::AddString(json_node,"Total Memory", std::to_string(total));
 		rvs::lp::AddString(json_node,"Free Memory", std::to_string(free));
-		rvs::lp::LogRecordFlush(json_node, rvs::logresults);
+		rvs::lp::LogRecordFlush(json_node, rvs::loginfo);
 	}
     } 
     allocate_small_mem();

--- a/mem.so/src/rvs_memworker.cpp
+++ b/mem.so/src/rvs_memworker.cpp
@@ -163,7 +163,6 @@ void MemWorker::run() {
     size_t          free;
     size_t          total;
     int             deviceId;
-    bool info_jsonlogs = false;  
 
     // log MEM stress test - start message
     msg = "[" + action_name + "] " + MODULE_NAME + " " +
@@ -199,7 +198,7 @@ void MemWorker::run() {
             std::to_string(total) + " " + " Free Memory from hipMemGetInfo " + " " + 
             std::to_string(free);
     rvs::lp::Log(msg, rvs::logtrace);
-    if (bjson && info_jsonlogs){
+    if (bjson){
 	void *json_node = json_node_create(std::string(MODULE_NAME),
       		action_name.c_str(), rvs::loginfo);
 	if (json_node){


### PR DESCRIPTION
schemas are specified for result logs so that json logs dont bloat much.
Moving the particular log to info level for now as it does not correlate to any specific tests