### PR TITLE
cherrypick to release branch : have a single place to init smi and shut down

### DIFF
--- a/babel.so/src/rvs_module.cpp
+++ b/babel.so/src/rvs_module.cpp
@@ -75,6 +75,7 @@ extern "C" int rvs_module_init(void* pMi) {
 
 extern "C" int rvs_module_terminate(void) {
     cleanup_logs();
+    amdsmi_shut_down();
     return 0;
 }
 

--- a/gm.so/src/rvs_module.cpp
+++ b/gm.so/src/rvs_module.cpp
@@ -75,7 +75,6 @@ extern "C" int   rvs_module_init(void* pMi) {
   rvs::lp::Initialize(static_cast<T_MODULE_INIT*>(pMi));
   RVSTRACE_
   rvs::gpulist::Initialize();
-  amdsmi_init(AMDSMI_INIT_AMD_GPUS);
   return 0;
 }
 

--- a/gm.so/test/test_1.cpp
+++ b/gm.so/test/test_1.cpp
@@ -26,10 +26,11 @@
 #include "include/action.h"
 #include "include/worker.h"
 #include "include/gpu_util.h"
-
+#include "amd_smi/amdsmi.h"
 Worker* pworker;
 
 TEST(gm, coverage_rsmi_failure) {
+  amdsmi_init(AMDSMI_INIT_AMD_GPUS);
   rvs::gpulist::Initialize();
   pworker = nullptr;
   gm_action* pa = new gm_action;
@@ -47,4 +48,5 @@ TEST(gm, coverage_rsmi_failure) {
   delete pa;
   pworker->stop();
   delete pworker;
+  amdsmi_shut_down();
 }

--- a/gpup.so/src/rvs_module.cpp
+++ b/gpup.so/src/rvs_module.cpp
@@ -69,6 +69,7 @@ extern "C" int rvs_module_init(void* pMi) {
 
 extern "C" int rvs_module_terminate(void) {
   cleanup_logs();
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/gst.so/src/rvs_module.cpp
+++ b/gst.so/src/rvs_module.cpp
@@ -74,6 +74,7 @@ extern "C" int rvs_module_init(void* pMi) {
 
 extern "C" int rvs_module_terminate(void) {
   cleanup_logs();
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/iet.so/src/rvs_module.cpp
+++ b/iet.so/src/rvs_module.cpp
@@ -70,7 +70,6 @@ extern "C" const char* rvs_module_get_output(void) {
 extern "C" int rvs_module_init(void* pMi) {
   rvs::lp::Initialize(static_cast<T_MODULE_INIT*>(pMi));
   rvs::gpulist::Initialize();
-  amdsmi_init(AMDSMI_INIT_AMD_GPUS);
   return 0;
 }
 

--- a/mem.so/src/rvs_module.cpp
+++ b/mem.so/src/rvs_module.cpp
@@ -85,6 +85,7 @@ extern "C" int rvs_module_init(void* pMi) {
 
 extern "C" int rvs_module_terminate(void) {
   cleanup_logs();
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/pbqt.so/src/rvs_module.cpp
+++ b/pbqt.so/src/rvs_module.cpp
@@ -76,6 +76,7 @@ extern "C" int   rvs_module_init(void* pMi) {
 extern "C" int   rvs_module_terminate(void) {
     rvs::hsa::Terminate();
     cleanup_logs();
+    amdsmi_shut_down();
     return 0;
 }
 

--- a/pebb.so/src/rvs_module.cpp
+++ b/pebb.so/src/rvs_module.cpp
@@ -80,6 +80,7 @@ extern "C" int   rvs_module_terminate(void) {
   rvs::lp::Log("[module_terminate] pebb rvs_module_terminate() - entered",
                rvs::logtrace);
   cleanup_logs();
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/peqt.so/src/rvs_module.cpp
+++ b/peqt.so/src/rvs_module.cpp
@@ -68,6 +68,7 @@ extern "C" int rvs_module_init(void* pMi) {
 
 extern "C" int rvs_module_terminate(void) {
   cleanup_logs();
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/perf.so/src/rvs_module.cpp
+++ b/perf.so/src/rvs_module.cpp
@@ -72,6 +72,7 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/pesm.so/src/rvs_module.cpp
+++ b/pesm.so/src/rvs_module.cpp
@@ -93,6 +93,7 @@ extern "C" int   rvs_module_terminate(void) {
                  rvs::logtrace);
   }
   cleanup_logs();
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/smqt.so/src/rvs_module.cpp
+++ b/smqt.so/src/rvs_module.cpp
@@ -72,6 +72,7 @@ extern "C" int   rvs_module_init(void* pMi) {
 }
 
 extern "C" int   rvs_module_terminate(void) {
+  amdsmi_shut_down();
   return 0;
 }
 

--- a/src/gpu_util.cpp
+++ b/src/gpu_util.cpp
@@ -225,13 +225,11 @@ void gpu_get_all_gpu_idx(std::vector<uint16_t>* pgpus_gpu_idx) {
   std::map<uint64_t, uint16_t> smi_map;
   //uint32_t smi_num_devices = 0;
   uint64_t gpuid;
-  amdsmi_init(AMDSMI_INIT_AMD_GPUS);
   amdsmi_status_t smi_ret;
   auto proc_handles = get_smi_processors();
   if (proc_handles.empty()){
     return;
   }
-  //amdsmi_init(AMDSMI_INIT_AMD_GPUS);
   for(auto i=0; i<proc_handles.size();++i ){
     amdsmi_kfd_info_t kfd_info;
     smi_ret = amdsmi_get_gpu_kfd_info(proc_handles[i], &kfd_info);
@@ -239,7 +237,6 @@ void gpu_get_all_gpu_idx(std::vector<uint16_t>* pgpus_gpu_idx) {
       smi_map.insert({kfd_info.kfd_id, i});
     }
   }
-  amdsmi_shut_down();
   ifstream f_id, f_prop;
   char path[KFD_PATH_MAX_LENGTH];
 
@@ -471,10 +468,7 @@ int gpu_hip_to_smi_hdl(int hip_index, amdsmi_processor_handle* smi_hdl) {
   if(hip_index >= hip_num_gpu_devices) {
     return -1;
   }
-  auto ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS);
-  //rvs::smi_pci_hdl_mapping();
   auto smi_map = rvs::get_smi_pci_map();
-  amdsmi_shut_down();
   /* Fetch Domain, Bus, Device and Function numbers from HIP PCIe id */
   uint64_t pDom = 0, pBus = 0, pDev = 0, pFun = 0;
   char pciString[256] = {0};
@@ -506,7 +500,7 @@ int gpu_hip_to_smi_hdl(int hip_index, amdsmi_processor_handle* smi_hdl) {
  * @return 0 if successful, -1 otherwise
  **/
 int rvs::gpulist::Initialize() {
-
+  amdsmi_init(AMDSMI_INIT_AMD_GPUS);
   gpu_get_all_location_id(&location_id);
   gpu_get_all_gpu_id(&gpu_id);
   gpu_get_all_gpu_idx(&gpu_idx);
@@ -742,10 +736,7 @@ int rvs::gpulist::gpu2domain(const uint16_t GpuID, uint16_t* pDomain) {
 bool gpu_check_if_gpu_indexes (const std::vector <uint16_t> &index) {
 
   uint32_t smi_num_devices = 0;
-  auto ret = amdsmi_init(AMDSMI_INIT_AMD_GPUS);
-  //rvs::smi_pci_hdl_mapping();
   smi_num_devices = rvs::get_smi_pci_map().size();
-  amdsmi_shut_down();
   for(auto i = 0; i < index.size(); i++) {
     if(index[i] >= smi_num_devices) {
       return false;

--- a/tst.so/src/rvs_module.cpp
+++ b/tst.so/src/rvs_module.cpp
@@ -68,7 +68,6 @@ extern "C" const char* rvs_module_get_output(void) {
 extern "C" int rvs_module_init(void* pMi) {
     rvs::lp::Initialize(static_cast<T_MODULE_INIT*>(pMi));
     rvs::gpulist::Initialize();
-    amdsmi_init(AMDSMI_INIT_AMD_GPUS);
     return 0;
 }
 


### PR DESCRIPTION
Instead of peppering init-shutdown over many places since almost all modules use gpu list function, keep smi init there and shutdown in module dtor