### PR TITLE
resolve description-synopsis-starts-with-article and description-too-long

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,7 @@ get_version ( ${RVS_VERSION} )
 # Package Generator  #######################################################
 set(CPACK_PACKAGE_NAME "rocm-validation-suite")
 set(CPACK_PACKAGE_DESCRIPTION "ROCm Validation Suite")
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "The ROCm Validation Suite (RVS) is a system validation and diagnostics tool for monitoring, stress testing, detecting and troubleshooting issues that affects the functionality and performance of AMD GPU(s) operating in a high-performance/AI/ML computing environment.")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "RVS is a system validation and diagnostics tool for monitoring, stress testing")
 set(CPACK_PACKAGE_VERSION_MAJOR "${PROJECT_VERSION_MAJOR}")
 set(CPACK_PACKAGE_VERSION_MINOR "${PROJECT_VERSION_MINOR}")
 set(CPACK_PACKAGE_VERSION_PATCH "${PROJECT_VERSION_PATCH}")


### PR DESCRIPTION
resolve description-synopsis-starts-with-article and description-too-long

## Motivation

Fix lintian description-too-long warning caused by description being greater or equal to 80 characters.
description-synopsis-starts-with-article omit descriptions that start with "a", "an", or "the".

## Technical Details

shorten description. Remove "The"

## Test Plan

recompile and check warning

## Test Result

no warning

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
