### PR TITLE
check in system path for third party library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,7 @@ message (STATUS "CPACK_GENERATOR ${CPACK_GENERATOR}" )
 find_library(YAML_CPP_STATIC_LIB 
   NAMES libyaml-cpp.a yaml-cpp.a
   PATHS /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib
+  NO_DEFAULT_PATH # avoid searches in cmake_install_prefix etc
   DOC "Path to yaml-cpp static library"
 )
 


### PR DESCRIPTION
## Motivation

Currently third party libs are to be searched for in system paths and not in rocm path
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
This change makes search for third party lib, yaml-cpp, in system path to avoid potential conflicts in rocm path

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
