### PR TITLE
default compute type is f32 which will be invalid if data is fp64

### DIFF
--- a/rvs/conf/MI350X/NPS2/CPX/gst_single.conf
+++ b/rvs/conf/MI350X/NPS2/CPX/gst_single.conf
@@ -357,6 +357,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192
@@ -380,6 +381,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: rand
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI350X/NPS2/DPX/gst_single.conf
+++ b/rvs/conf/MI350X/NPS2/DPX/gst_single.conf
@@ -357,6 +357,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192
@@ -380,6 +381,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: rand
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI350X/gst_single.conf
+++ b/rvs/conf/MI350X/gst_single.conf
@@ -357,6 +357,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192
@@ -380,6 +381,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: rand
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI350X/levels/rvs_level_4.conf
+++ b/rvs/conf/MI350X/levels/rvs_level_4.conf
@@ -299,6 +299,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI350X/levels/rvs_level_5.conf
+++ b/rvs/conf/MI350X/levels/rvs_level_5.conf
@@ -299,6 +299,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI355X/NPS2/CPX/gst_single.conf
+++ b/rvs/conf/MI355X/NPS2/CPX/gst_single.conf
@@ -357,6 +357,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192
@@ -380,6 +381,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: rand
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI355X/NPS2/DPX/gst_single.conf
+++ b/rvs/conf/MI355X/NPS2/DPX/gst_single.conf
@@ -357,6 +357,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192
@@ -380,6 +381,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: rand
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI355X/gst_single.conf
+++ b/rvs/conf/MI355X/gst_single.conf
@@ -357,6 +357,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192
@@ -380,6 +381,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: rand
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI355X/levels/rvs_level_4.conf
+++ b/rvs/conf/MI355X/levels/rvs_level_4.conf
@@ -299,6 +299,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192

--- a/rvs/conf/MI355X/levels/rvs_level_5.conf
+++ b/rvs/conf/MI355X/levels/rvs_level_5.conf
@@ -299,6 +299,7 @@ actions:
   matrix_size_c: 8192
   matrix_init: trig
   data_type: fp64_r
+  compute_type: fp64_r
   lda: 8192
   ldb: 8192
   ldc: 8192


### PR DESCRIPTION
instead of leaving compute_type values in config, which makes them take default fp32 value, this PR specifies it to take same precision as the data type

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
