### PR TITLE
rpm packages have different naming convention

### DIFF
--- a/rvs/conf/rcqt_single.conf
+++ b/rvs/conf/rcqt_single.conf
@@ -1,6 +1,6 @@
 # ################################################################################
 # #
-# # Copyright (c) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
+# # Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
 # #
 # # MIT LICENSE:
 # # Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -28,10 +28,10 @@ actions:
 - name: metapackage-validation
   device: all
   module: rcqt
-  package: rocm rocm-developer-tools rocm-openmp rocm-opencl-sdk rocm-hip 
+  package: rocm rocm-developer-tools rocm-openmp rocm-opencl-sdk rocm-hip
 
 - name: packagelist-install-validation
   device: all
   module: rcqt
-  debpackagelist: amd-smi-lib migraphx migraphx-dev miopen-hip miopen-hip-dev mivisionx mivisionx-dev rocm-cmake rocm-core rocminfo half rocm-llvm rpp rpp-dev roctracer-dev rocprofiler-sdk rocm-dbgapi hsa-amd-aqlprofile rocm-debug-agent rocprofiler-sdk-rocpd hsa-rocr hipblas hipblaslt rccl rocblas rocm-device-libs hipify-clang hipcc composablekernel-dev hiptensor comgr openmp-extras-runtime openmp-extras-dev rocm-language-runtime hip-runtime-amd    
-  rpmpackagelist: amd-smi-lib migraphx migraphx-dev miopen-hip miopen-hip-dev mivisionx mivisionx-dev rocm-cmake rocm-core rocminfo half rocm-llvm rpp rpp-dev roctracer-dev rocprofiler-sdk rocm-dbgapi hsa-amd-aqlprofile rocm-debug-agent rocprofiler-sdk-rocpd hsa-rocr hipblas hipblaslt rccl rocblas rocm-device-libs hipify-clang hipcc composablekernel-dev hiptensor comgr openmp-extras-runtime openmp-extras-dev rocm-language-runtime hip-runtime-amd    
+  debpackagelist: amd-smi-lib migraphx migraphx-dev miopen-hip miopen-hip-dev mivisionx mivisionx-dev rocm-cmake rocm-core rocminfo half rocm-llvm rpp rpp-dev roctracer-dev rocprofiler-sdk rocm-dbgapi hsa-amd-aqlprofile rocm-debug-agent rocprofiler-sdk-rocpd hsa-rocr hipblas hipblaslt rccl rocblas rocm-device-libs hipify-clang hipcc composablekernel-dev hiptensor comgr openmp-extras-runtime openmp-extras-dev rocm-language-runtime hip-runtime-amd
+  rpmpackagelist: amd-smi-lib migraphx migraphx-devel miopen-hip miopen-hip-devel mivisionx mivisionx-devel rocm-cmake rocm-core rocminfo half rocm-llvm rpp rpp-devel roctracer-devel rocprofiler-sdk rocm-dbgapi hsa-amd-aqlprofile rocm-debug-agent rocprofiler-sdk-rocpd hsa-rocr hipblas hipblaslt rccl rocblas rocm-device-libs hipify-clang hipcc composablekernel-devel hiptensor comgr openmp-extras-runtime openmp-extras-devel rocm-language-runtime hip-runtime-amd


### PR DESCRIPTION


## Motivation
for every *-dev package , rpm will have a *-devel. 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
in linux, for every *-dev package , rpm will have a *-devel.This convention was missing while checking. Updating the name for this
<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
