### PR TITLE
Fix redundant close braces in generic case

### DIFF
--- a/babel.so/src/rvs_module.cpp
+++ b/babel.so/src/rvs_module.cpp
@@ -74,7 +74,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/gpup.so/src/rvs_module.cpp
+++ b/gpup.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -68,7 +68,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/gst.so/src/rvs_module.cpp
+++ b/gst.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -73,7 +73,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/iet.so/src/rvs_module.cpp
+++ b/iet.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -74,7 +74,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/mem.so/src/rvs_module.cpp
+++ b/mem.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -84,7 +84,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/pbqt.so/src/rvs_module.cpp
+++ b/pbqt.so/src/rvs_module.cpp
@@ -75,7 +75,6 @@ extern "C" int rvs_module_init(void* pMi) {
 
 extern "C" int rvs_module_terminate(void) {
     rvs::hsa::Terminate();
-    cleanup_logs();
     amdsmi_shut_down();
     return 0;
 }

--- a/pebb.so/src/rvs_module.cpp
+++ b/pebb.so/src/rvs_module.cpp
@@ -79,7 +79,6 @@ extern "C" int   rvs_module_init(void* pMi) {
 extern "C" int   rvs_module_terminate(void) {
   rvs::lp::Log("[module_terminate] pebb rvs_module_terminate() - entered",
       rvs::logtrace);
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/peqt.so/src/rvs_module.cpp
+++ b/peqt.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2022 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -67,7 +67,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/pesm.so/src/rvs_module.cpp
+++ b/pesm.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -92,7 +92,6 @@ extern "C" int   rvs_module_terminate(void) {
       "[module_terminate] pesm rvs_module_terminate() - monitoring stopped",
                  rvs::logtrace);
   }
-  cleanup_logs();
   amdsmi_shut_down();
   return 0;
 }

--- a/rcqt.so/src/rvs_module.cpp
+++ b/rcqt.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -69,7 +69,6 @@ extern "C" int   rvs_module_init(void* pMi) {
 }
 
 extern "C" int   rvs_module_terminate(void) {
-  cleanup_logs();
   return 0;
 }
 

--- a/rvs/src/rvsexec_do_yaml.cpp
+++ b/rvs/src/rvsexec_do_yaml.cpp
@@ -794,7 +794,9 @@ int rvs::exec::do_yaml(yaml_data_type_t data_type, const std::string& data) {
   else {
     printBoundary();
   }
-
+  if (rvs::logger::to_json()) {
+    rvs::lp::JsonEndNodeCreate();
+  }
   result.status = RVS_STATUS_SUCCESS;
   result.output_log = "RVS session successfully completed.";
   callback(&result);

--- a/tst.so/src/rvs_module.cpp
+++ b/tst.so/src/rvs_module.cpp
@@ -1,6 +1,6 @@
 /********************************************************************************
  *
- * Copyright (c) 2018-2024 Advanced Micro Devices, Inc. All rights reserved.
+ * Copyright (c) 2018-2025 Advanced Micro Devices, Inc. All rights reserved.
  *
  * MIT LICENSE:
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -72,7 +72,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-    cleanup_logs();
     amdsmi_shut_down();
     return 0;
 }


### PR DESCRIPTION
levels config file will have mutliple actions belonging to different modules. as of now the closure happens at cleanup_logs() call which gets called mutliple times here hence we get this error.
Instead of splitting closure braces to each module terminate function, it must be called once and in centralised place so despite the number of modules in a conf file, json closure happens once