### PR TITLE
build!: bump cmake_minimum_required to 3.5.0

### DIFF
--- a/CMakeGtestDownload.cmake
+++ b/CMakeGtestDownload.cmake
@@ -23,7 +23,7 @@
 ##
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(googletest-download NONE)
 

--- a/CMakeLists.txt.yaml
+++ b/CMakeLists.txt.yaml
@@ -23,7 +23,7 @@
 ##
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(yaml-download NONE)
 

--- a/CMakeMXDataGeneratorDownload.cmake
+++ b/CMakeMXDataGeneratorDownload.cmake
@@ -23,7 +23,7 @@
 ##
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(mxDataGenerator-download NONE)
 

--- a/CMakeRBLASDownload.cmake
+++ b/CMakeRBLASDownload.cmake
@@ -23,7 +23,7 @@
 ##
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(rvs_rblas-download NONE)
 

--- a/CMakeRSMIDownload.cmake
+++ b/CMakeRSMIDownload.cmake
@@ -23,7 +23,7 @@
 ##
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5.0)
 
 project(rvs_smi-download NONE)
 


### PR DESCRIPTION
## Motivation

CMake 4 drops support of CMake older than 3.5, which leads to configuration failure.

The top level CMake file sets the minimum required version to 3.5.

https://github.com/ROCm/ROCmValidationSuite/blob/ca71668818ae3440af99392712807c4324534cda/CMakeLists.txt#L26

fix #1080

## Technical Details

https://cmake.org/cmake/help/v4.0/release/4.0.html#deprecated-and-removed-features

cmake issues the following warning

```
CMake Deprecation Warning at CMakeLists.txt:26 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

so at some point it is necessary to bump the version to 3.10 (or newer).

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

blocked by #1081 and #1083.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
