### PR TITLE
containerise ubuntu builds

### DIFF
--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -48,18 +48,36 @@ jobs:
   build-ubuntu:
     name: Build Ubuntu Packages
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
+    container:
+      image: ubuntu:${{ matrix.ubuntu_version }}
     strategy:
       matrix:
         ubuntu_version: ['22.04']
+    # Apply to every step in the job so apt never drops into an interactive
+    # frontend (tzdata, libssl, etc.) — each Actions step runs in a fresh
+    # shell, so an `export` inside one step does not propagate to the next.
+    env:
+      DEBIAN_FRONTEND: noninteractive
+      TZ: Etc/UTC
     outputs:
       s3_bucket_ubuntu: ${{ steps.upload-s3-ubuntu.outputs.bucket }}
       s3_paths_ubuntu: ${{ steps.upload-s3-ubuntu.outputs.paths }}
     
     steps:
-      - name: Clean workspace
+      # Bootstrap the bare ubuntu:* image so actions/checkout and downstream steps
+      # (dpkg-deb verify, apt-ftparchive, awscli) work without needing sudo on bare metal.
+      - name: Bootstrap container (git, curl, packaging tools)
         run: |
-          sudo rm -rf "${{ github.workspace }}/build" || true
-          sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}" || true
+          export DEBIAN_FRONTEND=noninteractive
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            curl \
+            git \
+            dpkg-dev \
+            apt-utils \
+            python3 \
+            python3-pip
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -82,18 +100,12 @@ jobs:
       - name: Build and Package RVS
         run: |
           chmod +x build_packages_local.sh
-           # Run build script with sudo (Ubuntu runner needs sudo for apt-get)
-          sudo -E ROCM_VERSION=${{ env.ROCM_VERSION }} \
+          ROCM_VERSION=${{ env.ROCM_VERSION }} \
           GPU_FAMILY=${{ env.GPU_FAMILY }} \
           BUILD_TYPE=${{ env.BUILD_TYPE }} \
           ROCM_SDK_BASE_URL=${{ vars.ROCM_SDK_BASE_URL }} \
           ROCM_SDK_INDEX_URL=${{ vars.ROCM_SDK_INDEX_URL }} \
           ./build_packages_local.sh
-
-      - name: Fix file ownership
-        if: always()
-        run: |
-          sudo chown -R $(id -u):$(id -g) "${{ github.workspace }}" || true
 
       - name: Verify DEB Package
         run: |
@@ -112,7 +124,7 @@ jobs:
       # S3 upload for repo ROCm/ROCmValidationSuite (schedule, push, pull request, manual)
       - name: Install AWS CLI
         if: github.repository == 'ROCm/ROCmValidationSuite'
-        run: sudo apt-get update && sudo apt-get install -y awscli
+        run: apt-get update && apt-get install -y awscli
 
       - name: Configure AWS credentials
         if: github.repository == 'ROCm/ROCmValidationSuite'
@@ -148,14 +160,14 @@ jobs:
             echo "Release branch build: uploading to release/rvs/deb"
             aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/deb/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
             echo "Listing s3://${BUCKET}/release/${BASE}/deb/"
-            aws s3 ls "s3://${BUCKET}/release/${BASE}/deb/" --human-readable
+            aws s3 ls "s3://${BUCKET}/release/${BASE}/deb/" --human-readable || true
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=Ubuntu DEB|release/${BASE}/deb" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "Nightly/push build: uploading to nightly/rvs/deb"
             aws s3 cp ./build "s3://${BUCKET}/nightly/${BASE}/deb/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
             echo "Listing s3://${BUCKET}/nightly/${BASE}/deb/"
-            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/deb/" --human-readable
+            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/deb/" --human-readable || true
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=Ubuntu DEB|nightly/${BASE}/deb" >> $GITHUB_OUTPUT
           else
@@ -163,7 +175,7 @@ jobs:
             echo "Uploading to s3://${BUCKET}/${PREFIX}/"
             aws s3 cp ./build "s3://${BUCKET}/${PREFIX}/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
             echo "Listing s3://${BUCKET}/${PREFIX}/"
-            aws s3 ls "s3://${BUCKET}/${PREFIX}/" --human-readable
+            aws s3 ls "s3://${BUCKET}/${PREFIX}/" --human-readable || true
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=Ubuntu DEB|${PREFIX}" >> $GITHUB_OUTPUT
           fi
@@ -178,7 +190,7 @@ jobs:
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           [ -z "$BUCKET" ] && exit 0
 
-          sudo apt-get update && sudo apt-get install -y dpkg-dev apt-utils
+          # dpkg-dev and apt-utils were installed in the Bootstrap container step.
 
           BASE="rvs"
           if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
@@ -204,7 +216,7 @@ jobs:
           aws s3 sync "$STAGING/" "s3://${BUCKET}/${DEB_PREFIX}/" --no-progress
 
           echo "=== DEB repo metadata uploaded to s3://${BUCKET}/${DEB_PREFIX}/ ==="
-          aws s3 ls "s3://${BUCKET}/${DEB_PREFIX}/" --human-readable
+          aws s3 ls "s3://${BUCKET}/${DEB_PREFIX}/" --human-readable || true
 
   build-centos:
     name: Build CentOS/RHEL Packages (manylinux_2_28)
@@ -310,9 +322,9 @@ jobs:
             aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/rpm/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
             aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/tar/" --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
             echo "Listing s3://${BUCKET}/release/${BASE}/rpm/"
-            aws s3 ls "s3://${BUCKET}/release/${BASE}/rpm/" --human-readable
+            aws s3 ls "s3://${BUCKET}/release/${BASE}/rpm/" --human-readable || true
             echo "Listing s3://${BUCKET}/release/${BASE}/tar/"
-            aws s3 ls "s3://${BUCKET}/release/${BASE}/tar/" --human-readable
+            aws s3 ls "s3://${BUCKET}/release/${BASE}/tar/" --human-readable || true
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=CentOS/RHEL RPM|release/${BASE}/rpm||CentOS/RHEL TGZ|release/${BASE}/tar" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -320,9 +332,9 @@ jobs:
             aws s3 cp ./build "s3://${BUCKET}/nightly/${BASE}/rpm/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
             aws s3 cp ./build "s3://${BUCKET}/nightly/${BASE}/tar/" --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
             echo "Listing s3://${BUCKET}/nightly/${BASE}/rpm/"
-            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/rpm/" --human-readable
+            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/rpm/" --human-readable || true
             echo "Listing s3://${BUCKET}/nightly/${BASE}/tar/"
-            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/tar/" --human-readable
+            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/tar/" --human-readable || true
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=CentOS/RHEL RPM|nightly/${BASE}/rpm||CentOS/RHEL TGZ|nightly/${BASE}/tar" >> $GITHUB_OUTPUT
           else
@@ -330,7 +342,7 @@ jobs:
             echo "Uploading to s3://${BUCKET}/${PREFIX}/"
             aws s3 cp ./build "s3://${BUCKET}/${PREFIX}/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --include "amdrocm*-rvs*.tar.gz" --no-progress
             echo "Listing s3://${BUCKET}/${PREFIX}/"
-            aws s3 ls "s3://${BUCKET}/${PREFIX}/" --human-readable
+            aws s3 ls "s3://${BUCKET}/${PREFIX}/" --human-readable || true
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=CentOS/RHEL packages|${PREFIX}" >> $GITHUB_OUTPUT
           fi
@@ -367,7 +379,7 @@ jobs:
           aws s3 sync "$STAGING/" "s3://${BUCKET}/${RPM_PREFIX}/" --no-progress
 
           echo "=== RPM repodata uploaded to s3://${BUCKET}/${RPM_PREFIX}/repodata/ ==="
-          aws s3 ls "s3://${BUCKET}/${RPM_PREFIX}/repodata/" --human-readable
+          aws s3 ls "s3://${BUCKET}/${RPM_PREFIX}/repodata/" --human-readable || true
 
   create-release:
     name: Create Release Summary

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       rocm_version:
-        description: 'ROCm version (e.g., 7.11.0a20260121)'
+        description: 'Optional pin — empty uses latest nightly (unless vars.ROCM_VERSION set). Release X.Y.Z vs nightly x.y.za… selects tarball host by format.'
         required: false
         default: ''
       gpu_family:
@@ -36,7 +36,9 @@ permissions:
   id-token: write
 
 env:
-  ROCM_VERSION: ${{ vars.ROCM_VERSION || '7.11.0a20260121' }}
+  # Leave unset unless you pin a version via repo variable or workflow_dispatch input.
+  # With vars.ROCM_SDK_RELEASE_URL set, the script picks latest X.Y.Z from that listing for GPU_FAMILY.
+  ROCM_VERSION: ${{ vars.ROCM_VERSION }}
   GPU_FAMILY: ${{ vars.GPU_FAMILY || 'gfx110X-all' }}
   BUILD_TYPE: Release
   # Optional Step 6 in build_packages_local.sh: set repo Actions variable
@@ -62,7 +64,7 @@ jobs:
     outputs:
       s3_bucket_ubuntu: ${{ steps.upload-s3-ubuntu.outputs.bucket }}
       s3_paths_ubuntu: ${{ steps.upload-s3-ubuntu.outputs.paths }}
-    
+
     steps:
       # Bootstrap the bare ubuntu:* image so actions/checkout and downstream steps
       # (dpkg-deb verify, apt-ftparchive, awscli) work without needing sudo on bare metal.
@@ -97,14 +99,87 @@ jobs:
             echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
           fi
 
+      # Schedule → latest ROCm *nightly*. PR + merge (push to main/master/release/*) → latest ROCm *release*.
+      # Manual: if a version is pinned (workflow input or vars.ROCM_VERSION), tarball follows *format* (auto).
+      - name: Configure ROCm SDK channel (nightly vs release)
+        run: |
+          NIGHTLY_BASE='${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}'
+          NIGHTLY_IDX='${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}'
+          [ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
+          [ -z "$NIGHTLY_IDX" ] && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
+
+          REL_URL='${{ vars.ROCM_SDK_RELEASE_URL }}'
+          [ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
+          REL_BASE='${{ vars.ROCM_SDK_RELEASE_BASE_URL }}'
+          [ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
+
+          release_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=release"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_BASE_URL=$REL_BASE"
+              echo "ROCM_SDK_INDEX_URL="
+            } >> "$GITHUB_ENV"
+          }
+
+          nightly_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=nightly"
+              echo "ROCM_SDK_RELEASE_URL="
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+            } >> "$GITHUB_ENV"
+          }
+
+          # Manual run with a pin: resolve tarball location by version format (nightly x.y.za… vs release X.Y.Z)
+          format_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=auto"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+            } >> "$GITHUB_ENV"
+          }
+
+          EVENT='${{ github.event_name }}'
+          REF='${{ github.ref }}'
+          IN_VER='${{ github.event.inputs.rocm_version }}'
+          VAR_VER='${{ vars.ROCM_VERSION }}'
+
+          if [ "$EVENT" = "schedule" ]; then
+            nightly_build
+            echo "ROCm SDK channel: nightly (scheduled — latest nightly)"
+          elif [ "$EVENT" = "pull_request" ]; then
+            release_build
+            echo "ROCm SDK channel: release (pull request — latest X.Y.Z)"
+          elif [ "$EVENT" = "push" ]; then
+            if [ "$REF" = "refs/heads/master" ] || [ "$REF" = "refs/heads/main" ] || [[ "$REF" == refs/heads/release/* ]]; then
+              release_build
+              echo "ROCm SDK channel: release (push to main or release/* — includes merge)"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (push to feature branch)"
+            fi
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
+              format_build
+              echo "ROCm SDK: manual — tarball base chosen by version format (input or vars.ROCM_VERSION)"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (manual, no version pin)"
+            fi
+          else
+            nightly_build
+            echo "ROCm SDK channel: nightly (fallback)"
+          fi
+
       - name: Build and Package RVS
         run: |
           chmod +x build_packages_local.sh
-          ROCM_VERSION=${{ env.ROCM_VERSION }} \
-          GPU_FAMILY=${{ env.GPU_FAMILY }} \
-          BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          ROCM_SDK_BASE_URL=${{ vars.ROCM_SDK_BASE_URL }} \
-          ROCM_SDK_INDEX_URL=${{ vars.ROCM_SDK_INDEX_URL }} \
+          # Container runs as root; ROCM_SDK_* come from "Configure ROCm SDK channel" via GITHUB_ENV.
           ./build_packages_local.sh
 
       - name: Verify DEB Package
@@ -121,13 +196,13 @@ jobs:
             echo "Package filename: $DEB_FILE"
           fi
 
-      # S3 upload for repo ROCm/ROCmValidationSuite (schedule, push, pull request, manual)
+      # S3 upload for ROCm/ROCmValidationSuite only (skip fork PRs: OIDC token response is empty → JSON parse fails)
       - name: Install AWS CLI
-        if: github.repository == 'ROCm/ROCmValidationSuite'
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: apt-get update && apt-get install -y awscli
 
       - name: Configure AWS credentials
-        if: github.repository == 'ROCm/ROCmValidationSuite'
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | python3 -c "import sys,json; print(json.load(sys.stdin)['value'])")
@@ -148,7 +223,7 @@ jobs:
       # S3 routing: release/* (push/manual) → release/; schedule/push/manual → nightly/; else → ref-specific
       - name: Upload Ubuntu packages to S3
         id: upload-s3-ubuntu
-        if: github.repository == 'ROCm/ROCmValidationSuite'
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           if [ -z "$BUCKET" ]; then
@@ -185,7 +260,7 @@ jobs:
       # can be consumed directly as a DEB repository by apt.
       # Only runs when the repository is ROCm/ROCmValidationSuite and the event is schedule, push, or manual.
       - name: Generate and upload DEB repo metadata to S3
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           [ -z "$BUCKET" ] && exit 0
@@ -195,8 +270,10 @@ jobs:
           BASE="rvs"
           if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
             DEB_PREFIX="release/${BASE}/deb"
+            APT_SUITE="rvs-release"
           else
             DEB_PREFIX="nightly/${BASE}/deb"
+            APT_SUITE="rvs-nightly"
           fi
 
           STAGING=$(mktemp -d)
@@ -210,8 +287,16 @@ jobs:
 
           cd "$STAGING"
           dpkg-scanpackages --multiversion . /dev/null > Packages
+          # dpkg-scanpackages emits "Filename: ./foo.deb". APT resolves that under the repo URL and may
+          # request .../deb/./foo.deb — S3/CloudFront keys are literal, so that path 404s. Strip "./".
+          sed -i 's#^Filename: \./#Filename: #g' Packages
           gzip -k -f Packages
-          apt-ftparchive release . > Release
+          apt-ftparchive \
+            -o APT::FTPArchive::Release::Origin="ROCm Validation Suite" \
+            -o APT::FTPArchive::Release::Label="${APT_SUITE}" \
+            -o APT::FTPArchive::Release::Suite="${APT_SUITE}" \
+            -o APT::FTPArchive::Release::Codename="${APT_SUITE}" \
+            release . > Release
 
           aws s3 sync "$STAGING/" "s3://${BUCKET}/${DEB_PREFIX}/" --no-progress
 
@@ -229,7 +314,7 @@ jobs:
     outputs:
       s3_bucket_centos: ${{ steps.upload-s3-centos.outputs.bucket }}
       s3_paths_centos: ${{ steps.upload-s3-centos.outputs.paths }}
-    
+
     steps:
       - name: Install Git (for checkout)
         run: |
@@ -253,15 +338,84 @@ jobs:
             echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
           fi
 
+      # Schedule → nightly latest. PR + merge → release latest. Manual → format when version pinned.
+      - name: Configure ROCm SDK channel (nightly vs release)
+        run: |
+          NIGHTLY_BASE='${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}'
+          NIGHTLY_IDX='${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}'
+          [ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
+          [ -z "$NIGHTLY_IDX" ] && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
+
+          REL_URL='${{ vars.ROCM_SDK_RELEASE_URL }}'
+          [ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
+          REL_BASE='${{ vars.ROCM_SDK_RELEASE_BASE_URL }}'
+          [ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
+
+          release_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=release"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_BASE_URL=$REL_BASE"
+              echo "ROCM_SDK_INDEX_URL="
+            } >> "$GITHUB_ENV"
+          }
+
+          nightly_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=nightly"
+              echo "ROCM_SDK_RELEASE_URL="
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+            } >> "$GITHUB_ENV"
+          }
+
+          format_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=auto"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+            } >> "$GITHUB_ENV"
+          }
+
+          EVENT='${{ github.event_name }}'
+          REF='${{ github.ref }}'
+          IN_VER='${{ github.event.inputs.rocm_version }}'
+          VAR_VER='${{ vars.ROCM_VERSION }}'
+
+          if [ "$EVENT" = "schedule" ]; then
+            nightly_build
+            echo "ROCm SDK channel: nightly (scheduled)"
+          elif [ "$EVENT" = "pull_request" ]; then
+            release_build
+            echo "ROCm SDK channel: release (pull request)"
+          elif [ "$EVENT" = "push" ]; then
+            if [ "$REF" = "refs/heads/master" ] || [ "$REF" = "refs/heads/main" ] || [[ "$REF" == refs/heads/release/* ]]; then
+              release_build
+              echo "ROCm SDK channel: release (push to main or release/*)"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (feature branch push)"
+            fi
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
+              format_build
+              echo "ROCm SDK: manual — format-based tarball"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (manual, no version)"
+            fi
+          else
+            nightly_build
+            echo "ROCm SDK channel: nightly (fallback)"
+          fi
+
       - name: Build and Package RVS
         run: |
           chmod +x build_packages_local.sh
-          
-          ROCM_VERSION=${{ env.ROCM_VERSION }} \
-          GPU_FAMILY=${{ env.GPU_FAMILY }} \
-          BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          ROCM_SDK_BASE_URL=${{ vars.ROCM_SDK_BASE_URL }} \
-          ROCM_SDK_INDEX_URL=${{ vars.ROCM_SDK_INDEX_URL }} \
           ./build_packages_local.sh
 
       - name: Verify RPM Package
@@ -281,14 +435,14 @@ jobs:
             echo "Package filename: $RPM_FILE"
           fi
 
-      # S3 upload for repo ROCm/ROCmValidationSuite (schedule, push, pull request, manual)
+      # S3 upload for ROCm/ROCmValidationSuite only (skip fork PRs — OIDC not usable)
       - name: Install AWS CLI
-        if: github.repository == 'ROCm/ROCmValidationSuite'
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           python3 -m pip install --break-system-packages awscli || (yum install -y python3-pip && pip3 install awscli)
 
       - name: Configure AWS credentials
-        if: github.repository == 'ROCm/ROCmValidationSuite'
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | python3 -c "import sys,json; print(json.load(sys.stdin)['value'])")
@@ -309,7 +463,7 @@ jobs:
       # S3 routing: release/* (push/manual) → release/; schedule/push/manual → nightly/; else → ref-specific
       - name: Upload CentOS/RHEL packages to S3
         id: upload-s3-centos
-        if: github.repository == 'ROCm/ROCmValidationSuite'
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           if [ -z "$BUCKET" ]; then
@@ -347,12 +501,12 @@ jobs:
             echo "paths=CentOS/RHEL packages|${PREFIX}" >> $GITHUB_OUTPUT
           fi
           echo "Done."
-      
+
       # Generate YUM/DNF repo metadata (repodata/) so the S3 path can be consumed
       # directly as an RPM repository by yum/dnf.
       # Only runs when the repository is ROCm/ROCmValidationSuite and the event is schedule, push, or manual.
       - name: Generate and upload RPM repodata to S3
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           [ -z "$BUCKET" ] && exit 0
@@ -387,7 +541,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
     # Only runs when the workflow is not cancelled and always() is true
     if: always() && !cancelled()
-    
+
     steps:
       - name: Generate Build Report
         run: |

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -95,6 +95,81 @@ fetch_latest_rocm_version() {
     return 0
 }
 
+# ROCm SDK CMake configs (e.g. hipblaslt-config.cmake) call block(), which was added
+# in CMake 3.25. Ubuntu 22.04 ships cmake 3.22 — too old.
+# Try Kitware's APT repo first (clean apt integration); fall back to pip for restricted
+# networks. Set RVS_SKIP_KITWARE_REPO=1 to skip the Kitware step (e.g. air-gapped runners).
+ensure_recent_cmake_ubuntu() {
+    [ -f /etc/os-release ] || return 0
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    case "${ID:-}" in
+        ubuntu|debian) ;;
+        *) return 0 ;;
+    esac
+    command -v apt-get >/dev/null 2>&1 || return 0
+
+    local need_major=3 need_minor=25
+    local cur_major=0 cur_minor=0 v=""
+    if command -v cmake >/dev/null 2>&1; then
+        v="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}')"
+        cur_major="${v%%.*}"
+        local _rest="${v#*.}"
+        cur_minor="${_rest%%.*}"
+        cur_major="${cur_major:-0}"
+        cur_minor="${cur_minor:-0}"
+        if { [ "$cur_major" -gt "$need_major" ] 2>/dev/null; } \
+           || { [ "$cur_major" -eq "$need_major" ] 2>/dev/null && [ "$cur_minor" -ge "$need_minor" ] 2>/dev/null; }; then
+            print_success "cmake $v is recent enough (>= ${need_major}.${need_minor})"
+            return 0
+        fi
+        print_info "cmake $v is older than ${need_major}.${need_minor}; upgrading (ROCm hipblaslt-config uses block())"
+    else
+        print_info "cmake not installed; installing recent version (>= ${need_major}.${need_minor})"
+    fi
+
+    # Try Kitware APT repo first
+    if [ -n "${VERSION_CODENAME:-}" ] && [ "${RVS_SKIP_KITWARE_REPO:-}" != "1" ]; then
+        print_info "Trying Kitware APT repo for cmake (codename: ${VERSION_CODENAME})..."
+        apt-get install -y --no-install-recommends ca-certificates gnupg wget >/dev/null 2>&1 || true
+        if wget -qO - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+            | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg 2>/dev/null \
+            && [ -s /usr/share/keyrings/kitware-archive-keyring.gpg ]; then
+            echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ ${VERSION_CODENAME} main" \
+                > /etc/apt/sources.list.d/kitware.list
+            if apt-get update >/dev/null 2>&1 && apt-get install -y --no-install-recommends cmake; then
+                hash -r
+                local v_new
+                v_new="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}')"
+                print_success "Installed cmake $v_new from Kitware APT repo"
+                return 0
+            fi
+            print_warning "Kitware APT install failed; falling back to pip"
+        else
+            print_warning "Could not reach apt.kitware.com; falling back to pip (set RVS_SKIP_KITWARE_REPO=1 to silence this)"
+        fi
+    fi
+
+    # pip fallback: works regardless of distro repo state, needs PyPI access.
+    if ! command -v pip3 >/dev/null 2>&1; then
+        apt-get install -y --no-install-recommends python3-pip >/dev/null 2>&1 || true
+    fi
+    if command -v pip3 >/dev/null 2>&1; then
+        if pip3 install --break-system-packages --upgrade cmake 2>/dev/null \
+           || pip3 install --upgrade cmake; then
+            hash -r
+            local v_new
+            v_new="$(cmake --version 2>/dev/null | head -1 | awk '{print $3}')"
+            print_success "Installed cmake $v_new via pip"
+            return 0
+        fi
+    fi
+
+    print_error "Could not install cmake >= ${need_major}.${need_minor}; ROCm hipblaslt configure will fail."
+    print_error "Either expose apt.kitware.com / PyPI to this runner, or pre-install cmake>=3.25 in the image."
+    return 1
+}
+
 # Function to check and install dependencies
 check_and_install_dependencies() {
     print_info "Checking for required build dependencies..."
@@ -292,6 +367,7 @@ check_and_install_dependencies() {
 
 # Check and install dependencies (installs wget, etc. - required before fetch_latest_rocm_version)
 check_and_install_dependencies
+ensure_recent_cmake_ubuntu
 
 # Determine ROCm version: use environment variable or fetch latest (wget is now available)
 if [ -n "$ROCM_VERSION" ]; then
@@ -429,6 +505,13 @@ export ROCM_LIBPATCH_VERSION
 export ROCM_MAJOR
 print_success "Set ROCM_LIBPATCH_VERSION=$ROCM_LIBPATCH_VERSION, ROCM_MAJOR=$ROCM_MAJOR (from $ROCM_VERSION_MAJOR_MINOR)"
 
+# Git 2.35+ refuses commands in container workspaces owned by a different UID than the
+# checkout (Actions mounts ${{ github.workspace }} into the container as root). Mark the
+# workspace as safe so subsequent git rev-parse calls below don't return "0000000".
+if [ -n "${GITHUB_WORKSPACE:-}" ] && command -v git >/dev/null 2>&1; then
+    git config --global --add safe.directory "$GITHUB_WORKSPACE" 2>/dev/null || true
+fi
+
 # Set CPACK package release based on event/branch type
 # - Base (schedule, push, workflow_dispatch, local): r<ROCM_LIBPATCH_VERSION>.yyyymmdd
 #   (ROCM_LIBPATCH_VERSION is major+minor as xxyy, e.g. 0711 for ROCm 7.11)
@@ -496,9 +579,26 @@ if [[ "$OS" =~ ^(centos|rhel|almalinux|rocky)$ ]]; then
     export CMAKE_COMMAND="cmake3"
     print_info "Using cmake3 (CentOS/RHEL/AlmaLinux/Rocky)"
 else
-    # Ubuntu and others: use defaults (system compiler and cmake)
+    # Ubuntu/Debian: modules (pebb/pbqt) compile with hipcc, which is Clang-based and does not
+    # bundle libstdc++ C++20 headers such as <barrier>. Pass the system GCC tree to hipcc via
+    # CMAKE_CXX_FLAGS --gcc-toolchain (same mechanism as GCC_TOOLCHAIN on RHEL).
     export CMAKE_COMMAND="cmake"
-    print_info "Using cmake (Ubuntu/other)"
+    print_info "Using cmake (Ubuntu/Debian/other)"
+
+    if [[ "$OS" =~ ^(ubuntu|debian)$ ]]; then
+        if [ -x "$ROCM_PATH/bin/hipcc" ]; then
+            export CMAKE_CXX_COMPILER="$ROCM_PATH/bin/hipcc"
+            print_success "Set CMAKE_CXX_COMPILER to hipcc (Ubuntu/Debian)"
+        else
+            print_warning "hipcc not found at $ROCM_PATH/bin/hipcc - using CMake default C++ compiler"
+        fi
+        if compgen -G "/usr/include/c++/*/barrier" >/dev/null 2>&1; then
+            export GCC_TOOLCHAIN="/usr"
+            print_success "Set GCC_TOOLCHAIN=/usr so hipcc finds system libstdc++ (C++20 <barrier>)"
+        else
+            print_warning "No /usr/include/c++/.../barrier found; install g++ 11+ (e.g. apt install g++-11 build-essential)"
+        fi
+    fi
 fi
 
 print_info "Environment variables set:"

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -13,13 +13,61 @@ BUILD_DIR="./build"
 ROCM_INSTALL_DIR="$HOME/rocm-sdk"
 
 # SDK Source Configuration
-# Default: TheRock public S3 nightly bucket (works from any network).
-# Override via environment variables or GitHub Actions repository variables (vars.*).
+# Defaults point at AMD-hosted listings (override via env or GitHub vars).
+# - Nightly index: https://rocm.nightlies.amd.com/tarball-multi-arch/
+# - Release listing: https://repo.amd.com/rocm/tarball/
 #
-# If your SDK server has no index page for auto-detection, set ROCM_SDK_INDEX_URL=""
-# and provide ROCM_VERSION explicitly.
-ROCM_SDK_BASE_URL="${ROCM_SDK_BASE_URL:-https://therock-nightly-tarball.s3.us-east-2.amazonaws.com}"
-ROCM_SDK_INDEX_URL="${ROCM_SDK_INDEX_URL:-https://therock-nightly-tarball.s3.amazonaws.com/index.html}"
+# Local builds: if ROCM_VERSION is unset (channel auto, no release listing env), latest *nightly* is fetched.
+# If ROCM_VERSION is set, tarball base follows format:
+# - Nightly: x.y.za<date> (e.g. 7.11.0a20260121) → nightly base URL
+# - Release: X.Y.Z (e.g. 7.11.0) → release base URL
+#
+# ROCM_SDK_CHANNEL: nightly | release | auto (default auto).
+# - nightly: latest SDK from nightly listing (ROCM_SDK_INDEX_URL).
+# - release: latest X.Y.Z from release listing (ROCM_SDK_RELEASE_URL).
+# - auto: release listing URL set → release discovery; else nightly index.
+#
+# Optional: ROCM_SDK_NIGHTLY_BASE_URL, ROCM_SDK_NIGHTLY_INDEX_URL, ROCM_SDK_RELEASE_URL (listing),
+# ROCM_SDK_RELEASE_BASE_URL (tarball directory for X.Y.Z downloads).
+_ROCM_NIGHTLY_INDEX_DEFAULT="https://rocm.nightlies.amd.com/tarball-multi-arch/"
+_ROCM_NIGHTLY_BASE_DEFAULT="https://rocm.nightlies.amd.com/tarball-multi-arch"
+_ROCM_RELEASE_LIST_DEFAULT="https://repo.amd.com/rocm/tarball/"
+_ROCM_RELEASE_BASE_DEFAULT="https://repo.amd.com/rocm/tarball"
+
+ROCM_SDK_CHANNEL="${ROCM_SDK_CHANNEL:-auto}"
+ROCM_SDK_RELEASE_URL="${ROCM_SDK_RELEASE_URL:-}"
+
+if [ "$ROCM_SDK_CHANNEL" = "nightly" ]; then
+    ROCM_SDK_RELEASE_URL=""
+    ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_NIGHTLY_INDEX_URL:-${ROCM_SDK_INDEX_URL:-$_ROCM_NIGHTLY_INDEX_DEFAULT}}"
+elif [ "$ROCM_SDK_CHANNEL" = "release" ]; then
+    ROCM_SDK_RELEASE_URL="${ROCM_SDK_RELEASE_URL:-$_ROCM_RELEASE_LIST_DEFAULT}"
+    if [ -z "${ROCM_SDK_BASE_URL:-}" ]; then
+        if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
+            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
+        else
+            # Same directory as listing: strip trailing / only (not %/* — that drops /tarball when URL has no trailing slash).
+            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/}"
+        fi
+    fi
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_INDEX_URL:-}"
+else
+    # auto (local: no release URL → nightly latest; CI sets channel explicitly)
+    if [ -n "${ROCM_SDK_RELEASE_URL}" ]; then
+        if [ -z "${ROCM_SDK_BASE_URL:-}" ]; then
+            if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
+                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
+            else
+                # Listing URL and tarball base share the same path; normalize trailing slash only.
+                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/}"
+            fi
+        fi
+    else
+        ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+    fi
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_NIGHTLY_INDEX_URL:-${ROCM_SDK_INDEX_URL:-$_ROCM_NIGHTLY_INDEX_DEFAULT}}"
+fi
 
 # Post-build upload configuration
 # Set UPLOAD_TARGET to enable automatic upload of built packages after the build.
@@ -69,6 +117,27 @@ print_error() {
     echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
+# Join base URL and filename without duplicate slashes
+join_base_and_file() {
+    local base="$1"
+    local path="$2"
+    base="${base%/}"
+    printf '%s/%s' "$base" "$path"
+}
+
+# After ROCM_VERSION is known: pick tarball host directory from version shape (overrides channel defaults).
+# Nightly: x.y.za<digits>  Release: X.Y.Z (three-part semver only)
+apply_sdk_tarball_base_for_version() {
+    local v="$1"
+    if echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+a[0-9]+'; then
+        ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+        print_info "Version matches ROCm nightly format (x.y.za…) → tarball base: $ROCM_SDK_BASE_URL"
+    elif echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_RELEASE_BASE_DEFAULT}}"
+        print_info "Version matches ROCm release format (X.Y.Z) → tarball base: $ROCM_SDK_BASE_URL"
+    fi
+}
+
 # Function to fetch latest ROCm version for specified GPU family
 # Sets the global ROCM_VERSION variable directly
 fetch_latest_rocm_version() {
@@ -82,15 +151,37 @@ fetch_latest_rocm_version() {
     local latest_version=$(wget -qO- "$ROCM_SDK_INDEX_URL" 2>/dev/null | \
         grep -oP "therock-dist-linux-${gpu_family}-\K[^<\"]+(?=\.tar\.gz)" | \
         sort -V | tail -1)
-    
+
     if [ -z "$latest_version" ]; then
-        print_error "Could not fetch latest ROCm version for $gpu_family"
-        print_info "Falling back to default version: 7.11.0a20260121"
-        ROCM_VERSION="7.11.0a20260121"
+        print_error "Could not fetch latest ROCm nightly version for $gpu_family from $ROCM_SDK_INDEX_URL"
         return 1
     fi
-    
+
     print_success "Found latest ROCm version: $latest_version"
+    ROCM_VERSION="$latest_version"
+    return 0
+}
+
+# Fetch latest ROCm *release* tarball version (semantic X.Y.Z only; excludes nightly builds like 7.11.0a20260121).
+# Parses ROCM_SDK_RELEASE_URL (HTML listing / index). Sets ROCM_VERSION.
+fetch_latest_rocm_release_version() {
+    local gpu_family="$1"
+    local list_url="${ROCM_SDK_RELEASE_URL:-$_ROCM_RELEASE_LIST_DEFAULT}"
+
+    print_info "Fetching latest ROCm release version (X.Y.Z) for $gpu_family..."
+    print_info "Release listing URL: $list_url"
+
+    local latest_version
+    latest_version=$(wget -qO- "$list_url" 2>/dev/null | \
+        grep -oP "therock-dist-linux-${gpu_family}-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.tar\.gz)" | \
+        sort -V | uniq | tail -1)
+
+    if [ -z "$latest_version" ]; then
+        print_error "No therock-dist-linux-${gpu_family}-X.Y.Z.tar.gz found under release listing (expected forms like 7.11.0)"
+        return 1
+    fi
+
+    print_success "Found latest ROCm release version: $latest_version"
     ROCM_VERSION="$latest_version"
     return 0
 }
@@ -173,7 +264,7 @@ ensure_recent_cmake_ubuntu() {
 # Function to check and install dependencies
 check_and_install_dependencies() {
     print_info "Checking for required build dependencies..."
-    
+
     # Detect OS
     if [ -f /etc/os-release ]; then
         . /etc/os-release
@@ -182,7 +273,7 @@ check_and_install_dependencies() {
         print_error "Cannot detect OS. Please install dependencies manually."
         exit 1
     fi
-    
+
     # Check for command-line tools
     MISSING_TOOLS=()
     command -v cmake >/dev/null 2>&1 || MISSING_TOOLS+=("cmake")
@@ -194,7 +285,7 @@ check_and_install_dependencies() {
     command -v tar >/dev/null 2>&1 || MISSING_TOOLS+=("tar")
     command -v doxygen >/dev/null 2>&1 || MISSING_TOOLS+=("doxygen")
     command -v python3 >/dev/null 2>&1 || MISSING_TOOLS+=("python3")
-    
+
     # Check for library dependencies (platform-specific)
     MISSING_LIBS=()
     if [[ "$OS" =~ ^(ubuntu|debian)$ ]]; then
@@ -211,16 +302,16 @@ check_and_install_dependencies() {
         [ -f /usr/include/numa.h ] || MISSING_LIBS+=("numactl-devel")
         command -v rpmbuild >/dev/null 2>&1 || MISSING_LIBS+=("rpm-build")
     fi
-    
+
     # Combine missing tools and libraries
     MISSING_DEPS=()
     [ ${#MISSING_TOOLS[@]} -ne 0 ] && MISSING_DEPS+=("${MISSING_TOOLS[@]}")
     [ ${#MISSING_LIBS[@]} -ne 0 ] && MISSING_DEPS+=("${MISSING_LIBS[@]}")
-    
+
     if [ ${#MISSING_DEPS[@]} -ne 0 ]; then
         print_warning "Missing dependencies: ${MISSING_DEPS[*]}"
         echo ""
-        
+
         if [[ "$OS" =~ ^(ubuntu|debian)$ ]]; then
             print_info "Installing dependencies for Ubuntu/Debian..."
             apt-get update
@@ -239,12 +330,12 @@ check_and_install_dependencies() {
                 libnuma-dev
         elif [[ "$OS" =~ ^(centos|rhel|rocky|almalinux|amzn)$ ]]; then
             print_info "Installing dependencies for CentOS/RHEL/Rocky/AlmaLinux..."
-            
+
             # Check if running in manylinux container (has /opt/python)
             if [ -d /opt/python ]; then
                 print_info "Detected manylinux environment - some tools may be pre-installed"
             fi
-            
+
             # Enable PowerTools/CRB repository (contains doxygen and yaml-cpp)
             print_info "Enabling PowerTools/CRB repository..."
             if command -v dnf >/dev/null 2>&1; then
@@ -262,11 +353,11 @@ check_and_install_dependencies() {
                 yum-config-manager --enable devel 2>/dev/null || \
                 print_warning "Could not enable PowerTools/devel repo (may already be enabled)"
             fi
-            
+
             # Install EPEL repository (may already be present in manylinux)
             print_info "Installing EPEL repository..."
             yum install -y epel-release 2>/dev/null || print_warning "EPEL may already be installed"
-            
+
             print_info "Installing build dependencies..."
             # Note: manylinux typically has gcc, g++, make pre-installed
             yum install -y \
@@ -282,7 +373,7 @@ check_and_install_dependencies() {
                 python3 \
                 numactl-devel \
                 || print_warning "Some packages may already be installed"
-            
+
             # Install a gcc-toolset with C++20 <barrier> support (requires GCC >= 11)
             # Try highest available first for best C++20/C++23 support, fall back to minimum viable
             # RHEL/AlmaLinux/Rocky 8+ use gcc-toolset-{ver}, CentOS 7 uses devtoolset-{ver}
@@ -312,11 +403,11 @@ check_and_install_dependencies() {
                     print_warning "No gcc-toolset (11-14) or devtoolset-11 available - C++20 headers like <barrier> may be missing"
                 fi
             fi
-            
+
             # Install cmake and yaml-cpp separately as they may need special handling
             print_info "Installing cmake..."
             yum install -y cmake3 || yum install -y cmake || print_warning "cmake installation may have failed"
-            
+
             print_info "Installing yaml-cpp..."
             yum install -y yaml-cpp-devel yaml-cpp-static 2>/dev/null || \
             print_warning "yaml-cpp may not be available - will try to continue"
@@ -341,10 +432,10 @@ check_and_install_dependencies() {
             echo "  - rpm-build tools"
             exit 1
         fi
-        
+
         print_success "Dependencies installed successfully"
         echo ""
-        
+
         # Verify installation by re-checking
         print_info "Verifying installation..."
         VERIFY_FAILED=()
@@ -353,7 +444,7 @@ check_and_install_dependencies() {
                 VERIFY_FAILED+=("$tool")
             fi
         done
-        
+
         if [ ${#VERIFY_FAILED[@]} -ne 0 ]; then
             print_error "Failed to install: ${VERIFY_FAILED[*]}"
             exit 1
@@ -369,12 +460,40 @@ check_and_install_dependencies() {
 check_and_install_dependencies
 ensure_recent_cmake_ubuntu
 
-# Determine ROCm version: use environment variable or fetch latest (wget is now available)
+# Determine ROCm version: explicit env > channel-specific listing
 if [ -n "$ROCM_VERSION" ]; then
     print_info "Using specified ROCm version: $ROCM_VERSION"
+elif [ "$ROCM_SDK_CHANNEL" = "nightly" ]; then
+    print_info "No ROCm version specified; fetching latest from ROCm nightly index (channel=nightly)..."
+    if [ -z "$ROCM_SDK_INDEX_URL" ]; then
+        print_error "ROCM_SDK_CHANNEL=nightly requires ROCM_SDK_INDEX_URL"
+        exit 1
+    fi
+    fetch_latest_rocm_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm nightly version"
+        exit 1
+    fi
+elif [ "$ROCM_SDK_CHANNEL" = "release" ]; then
+    print_info "No ROCm version specified; fetching latest release X.Y.Z from ROCM_SDK_RELEASE_URL..."
+    if [ -z "$ROCM_SDK_RELEASE_URL" ]; then
+        print_error "ROCM_SDK_CHANNEL=release requires ROCM_SDK_RELEASE_URL when ROCM_VERSION is unset"
+        exit 1
+    fi
+    fetch_latest_rocm_release_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm release version"
+        exit 1
+    fi
+elif [ -n "$ROCM_SDK_RELEASE_URL" ]; then
+    print_info "No ROCm version specified; resolving latest release from ROCM_SDK_RELEASE_URL (channel=auto)..."
+    fetch_latest_rocm_release_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm release version"
+        exit 1
+    fi
 elif [ -n "$ROCM_SDK_INDEX_URL" ]; then
-    # Auto-detection only works when an index URL is available (e.g. S3 bucket)
-    print_info "No ROCm version specified, fetching latest from index..."
+    print_info "No ROCm version specified, fetching latest from nightly index (channel=auto)..."
     fetch_latest_rocm_version "$GPU_FAMILY"
 
     if [ -z "$ROCM_VERSION" ]; then
@@ -383,25 +502,23 @@ elif [ -n "$ROCM_SDK_INDEX_URL" ]; then
     fi
 else
     print_error "ROCM_VERSION is required"
-    print_info "The configured SDK server does not provide an index page for auto-detection."
-    print_info "Set it via environment variable, e.g.:"
+    print_info "Set ROCM_VERSION, or configure ROCM_SDK_RELEASE_URL (release X.Y.Z tarballs) or ROCM_SDK_INDEX_URL (nightly listing)."
+    print_info "Example:"
     echo ""
-    echo "  export ROCM_VERSION=\"7.11.0a20260121\""
+    echo "  export ROCM_VERSION=\"7.11.0\""
     echo "  ./build_packages_local.sh"
-    echo ""
-    print_info "Or in GitHub Actions workflow:"
-    echo ""
-    echo "  env:"
-    echo "    ROCM_VERSION: \"7.11.0a20260121\""
     echo ""
     exit 1
 fi
+
+apply_sdk_tarball_base_for_version "$ROCM_VERSION"
 
 # Print configuration
 echo "================================================================================"
 echo "  ROCm Validation Suite - Local Package Build Script"
 echo "================================================================================"
 print_info "ROCm Version: $ROCM_VERSION"
+print_info "ROCm SDK channel: ${ROCM_SDK_CHANNEL:-auto}"
 print_info "GPU Family: $GPU_FAMILY"
 print_info "Build Type: $BUILD_TYPE"
 print_info "Build Directory: $BUILD_DIR"
@@ -416,7 +533,7 @@ echo ""
 
 # Step 1: Download ROCm SDK
 print_info "Step 1: Downloading ROCm SDK tarball..."
-TARBALL_URL="${ROCM_SDK_BASE_URL}/therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz"
+TARBALL_URL=$(join_base_and_file "$ROCM_SDK_BASE_URL" "therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz")
 TARBALL_FILE="$ROCM_INSTALL_DIR/rocm-sdk.tar.gz"
 
 mkdir -p "$ROCM_INSTALL_DIR"
@@ -455,13 +572,13 @@ if [ -z "$goto_step2" ]; then
         print_info "Please check if the ROCm version and GPU family are correct"
         exit 1
     fi
-    
+
     # Extract tarball
     print_info "Extracting ROCm SDK..."
     mkdir -p "$ROCM_INSTALL_DIR/install"
     tar -xzf "$TARBALL_FILE" -C "$ROCM_INSTALL_DIR/install" --strip-components=1
     print_success "Extraction complete"
-    
+
     export ROCM_PATH="$ROCM_INSTALL_DIR/install"
     print_success "ROCm SDK installed to: $ROCM_PATH"
 fi
@@ -574,7 +691,7 @@ if [[ "$OS" =~ ^(centos|rhel|almalinux|rocky)$ ]]; then
     else
         print_warning "hipcc not found at $ROCM_PATH/bin/hipcc - using system default compiler"
     fi
-    
+
     # Use cmake3 for RHEL-based distros
     export CMAKE_COMMAND="cmake3"
     print_info "Using cmake3 (CentOS/RHEL/AlmaLinux/Rocky)"
@@ -645,8 +762,8 @@ if [ -d "$BUILD_DIR" ]; then
     rm -rf "$BUILD_DIR"
 fi
 
-# Build cmake command with optional CXX compiler
-# TODO: May be cleanup RPATH later with lesser options.
+# Build cmake command with optional CXX compiler.
+# CMAKE_INSTALL_RPATH / CMAKE_SKIP_RPATH / CMAKE_INSTALL_RPATH_USE_LINK_PATH live in CMakeLists.txt.
 CMAKE_ARGS=(
     -B "$BUILD_DIR"
     -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
@@ -656,10 +773,6 @@ CMAKE_ARGS=(
     -DCPACK_PACKAGE_NAME="amdrocm${ROCM_MAJOR}-rvs"
     -DCMAKE_INSTALL_PREFIX="/opt/rocm/extras-${ROCM_MAJOR}"
     -DCPACK_PACKAGING_INSTALL_PREFIX="/opt/rocm/extras-${ROCM_MAJOR}"
-    -DCMAKE_SKIP_RPATH=FALSE
-    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE
-    -DCMAKE_INSTALL_RPATH="\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../lib/rvs:/opt/rocm/extras-${ROCM_MAJOR}/lib"
-    -DRPATH_MODE=OFF
     -DCMAKE_VERBOSE_MAKEFILE=1
     -DFETCH_ROCMPATH_FROM_ROCMCORE=ON
 )
@@ -708,14 +821,14 @@ if command -v dpkg >/dev/null 2>&1; then
     print_info "Creating DEB package..."
     cd "$BUILD_DIR"
     cpack -G DEB --verbose
-    
+
     if [ $? -eq 0 ]; then
         DEB_FILE=$(ls amdrocm*-rvs*.deb 2>/dev/null | head -1)
         if [ -n "$DEB_FILE" ]; then
             print_success "Created DEB package: $DEB_FILE"
             DEB_SIZE=$(du -h "$DEB_FILE" | cut -f1)
             print_info "Package size: $DEB_SIZE"
-            
+
             # Verify DEB package
             print_info "Verifying DEB package..."
             dpkg-deb -I "$DEB_FILE" | head -20
@@ -732,14 +845,14 @@ if command -v rpm >/dev/null 2>&1; then
     cd "$BUILD_DIR"
     cpack -G RPM --verbose
 
-    
+
     if [ $? -eq 0 ]; then
         RPM_FILE=$(ls amdrocm*-rvs*.rpm 2>/dev/null | head -1)
         if [ -n "$RPM_FILE" ]; then
             print_success "Created RPM package: $RPM_FILE"
             RPM_SIZE=$(du -h "$RPM_FILE" | cut -f1)
             print_info "Package size: $RPM_SIZE"
-            
+
             # Verify RPM package
             print_info "Verifying RPM package..."
             rpm -qip "$RPM_FILE" | head -20


### PR DESCRIPTION
Containerise Ubuntu build job (ubuntu:22.04 docker)

Run the Ubuntu workflow inside an `ubuntu:22.04` container so the build is
reproducible regardless of host

* `ensure_recent_cmake_ubuntu()`: For dependent cmake files calling block(),
  added in CMake 3.25 but Ubuntu 22.04 ships 3.22. Try Kitware APT repo first,
  fall back to pip; gated by `RVS_SKIP_KITWARE_REPO` for air-gapped runners.
* Mark `$GITHUB_WORKSPACE` as `safe.directory` - container UID differs from
  the checkout owner so git rev-parse otherwise yields "0000000".
* In the Ubuntu/Debian branch, point `CMAKE_CXX_COMPILER` at hipcc and set
  `GCC_TOOLCHAIN=/usr` when /usr/include/c++/*/barrier exists, mirroring the
  `--gcc-toolchain` plumbing already used for RHEL/AlmaLinux. Without this
  hipcc (clang) cannot find C++20 <barrier> against the system libstdc++.