### PR TITLE
fetch path and version relative to install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,11 +47,12 @@ if ( ${CMAKE_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   message(FATAL "In-source build is not allowed")
 endif ()
 enable_testing()
-# In future use the api provided by rocm-core library to get ROCm Install path
-# For backward compatibility use ROCM_PATH provided by build arguments.
-# Using the api option is turned OFF by default
+# When ON, link rocm-core: getROCmInstallPath for the ROCm install path, and
+# getROCmVersion (rocm_version.h) for the YAML system-overview ROCm string — no
+# .info file read for that path. When OFF, use ROCM_PATH and the version file
+# under that prefix only.
 option(FETCH_ROCMPATH_FROM_ROCMCORE
-        "Use the api provided by rocm-core library to get ROCM_PATH" OFF)
+        "Use rocm-core C API for ROCm path and YAML system-overview ROCm version" OFF)
 
 # Prerequisite - Check if rocblas was already installed
 find_package (rocblas)
@@ -196,20 +197,21 @@ set(CMAKE_INSTALL_PREFIX "/opt/rocm/extras-${ROCM_MAJOR_VERSION}" CACHE PATH "CM
 set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm/extras-${ROCM_MAJOR_VERSION}" CACHE PATH "Prefix used in built packages")
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}")
 
+# Compile-time default used by rvs_get_rocm_install_path_string() after
+# getROCmInstallPath (if FETCH_*) and $ROCM_PATH env are considered.
 add_definitions(-DROCM_PATH="${ROCM_PATH}")
 if(FETCH_ROCMPATH_FROM_ROCMCORE)
   add_compile_options(-DFETCH_ROCMPATH_FROM_ROCMCORE=${FETCH_ROCMPATH_FROM_ROCMCORE})
-  # rocm-core library will provide the ROCM_PATH during runtime
-  # Link the library as required
   set(ROCM_CORE "rocm-core")
-  # The absolute library path will be ${ROCM_PATH}/${RVS_LIB_PATH}
-  # Usage is ROCM_PATH will be fetched from rocm-core and append ${RVS_LIB_PATH}
-  add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_LIBDIR}/rvs")
 else()
-  add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/rvs")
-  # Set ROCM_CORE to empty, so no linking to rocm-core library/package
   set(ROCM_CORE "")
 endif()
+# RVS module .so and shared data (conf) live under the RVS install prefix, not under ROCm.
+add_definitions(-DRVS_LIB_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/rvs")
+add_definitions(-DRVS_DATA_ROOT="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}")
+# Suffixes relative to that prefix for runtime resolution from the rvs binary path.
+add_definitions(-DRVS_RELPATH_DATA_DIR="${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME}")
+add_definitions(-DRVS_RELPATH_MODULE_LIB_DIR="${CMAKE_INSTALL_LIBDIR}/rvs")
 #
 # If the user specifies -DCMAKE_BUILD_TYPE on the command line, take their
 # definition and dump it in the cache along with proper documentation,

--- a/include/rvs_util.h
+++ b/include/rvs_util.h
@@ -70,8 +70,8 @@ std::string rvs_get_rocm_install_path_string(void);
 
 /**
  * RVS data root .../share/.../rocm-validation-suite: RVS_PREFIX env, else path
- * derived from the running rvs process (*/bin/rvs -> install prefix) on Linux,
- * else the build-time RVS_DATA_ROOT macro.
+ * derived from the running rvs process (e.g. prefix/bin/rvs) on Linux,
+ * else the build-time RVS_DATA_ROOT macro. Install prefix is the parent of bin/.
  */
 std::string rvs_get_rvs_data_root_string(void);
 /** RVS module lib directory .../lib/rvs — same resolution order. */

--- a/include/rvs_util.h
+++ b/include/rvs_util.h
@@ -60,6 +60,24 @@ extern std::vector<std::string> str_split(const std::string& str_val,
         const std::string& delimiter);
 
 /**
+ * ROCm install **root** for runtime: if built with FETCH_ROCMPATH_FROM_ROCMCORE,
+ * tries getROCmInstallPath (rocm-core) first, then the ROCM_PATH environment
+ * variable, then the build-time ROCM_PATH string. Otherwise: getenv(ROCM_PATH)
+ * first, then the build-time macro. Use this to resolve relocatable or
+ * non-default ROCm locations instead of relying on the prebuilt #define alone.
+ */
+std::string rvs_get_rocm_install_path_string(void);
+
+/**
+ * RVS data root .../share/.../rocm-validation-suite: RVS_PREFIX env, else path
+ * derived from the running rvs process (*/bin/rvs -> install prefix) on Linux,
+ * else the build-time RVS_DATA_ROOT macro.
+ */
+std::string rvs_get_rvs_data_root_string(void);
+/** RVS module lib directory .../lib/rvs — same resolution order. */
+std::string rvs_get_rvs_modules_lib_dir_string(void);
+
+/**
  * Convert array of strings into array of signed integers of type T
  * @param sArr input string
  * @param iArr tokens' delimiter

--- a/rvs/src/rvsexec.cpp
+++ b/rvs/src/rvsexec.cpp
@@ -38,9 +38,7 @@
 #include "include/rvsliblogger.h"
 #include "include/rvsoptions.h"
 #include "include/rvstrace.h"
-#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
-#include "rocm-core/rocm_getpath.h"
-#endif
+#include "include/rvs_util.h"
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -397,24 +395,6 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
   string  module;
   string config;
   yaml_data_type_t data_type;
-#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
-  char *installPath = nullptr;
-  unsigned int installPathLen = 0;
-  string rocmPath;
-  PathErrors_t retVal = PathSuccess;
-  // Get ROCM install path
-  retVal = getROCmInstallPath( &installPath, &installPathLen );
-  if(retVal == PathSuccess){
-    rocmPath = installPath;
-  }
-  else {
-    std::cout << "Failed to get ROCm Install Path: " << retVal <<"\nSet ROCM_PATH in env" << std::endl;
-  }
-  // free allocated memory
-  if(installPath != nullptr) {
-    free(installPath);
-  }
-#endif
   options::has_option("pwd", &path);
   logger::log_level(rvs::logerror);
 
@@ -466,13 +446,9 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
       config = "conf/" + module_config_file[module_index];
       std::ifstream file(path + config);
       if (!file.good()) {
-        // configuration file exist in ROCM path ?
-#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
-        path = rocmPath;
-#else
-        path = ROCM_PATH;
-#endif
-        config = "/share/rocm-validation-suite/conf/" + module_config_file[module_index];
+        // RVS data dir: from rvs binary, $RVS_PREFIX, or build-time RVS_DATA_ROOT
+        path = rvs_get_rvs_data_root_string();
+        config = "/conf/" + module_config_file[module_index];
       }
       file.close();
     }
@@ -508,13 +484,8 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
     val = path + ".rvsmodules.config";
     std::ifstream conf_file(val);
     if (!conf_file.good()) {
-      // Modules config. file exist in ROCM path ?
-#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
-      path = rocmPath;
-#else
-      path = ROCM_PATH;
-#endif
-      val = path + "/share/rocm-validation-suite/conf/.rvsmodules.config";
+      path = rvs_get_rvs_data_root_string();
+      val = path + "/conf/.rvsmodules.config";
     }
   }
   conf_file.close();

--- a/rvs/src/rvsexec_do_yaml.cpp
+++ b/rvs/src/rvsexec_do_yaml.cpp
@@ -45,7 +45,28 @@
 #include "include/rvs_util.h"
 #include "include/gpu_util.h"
 
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
+#include "rocm-core/rocm_version.h"
+#endif
+
 #define MODULE_NAME_CAPS "CLI"
+
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
+/**
+ * C API getROCmVersion (rocm_version.h) must be called from a function declared
+ * before the C++ getROCmVersion in this file so the name does not self-resolve.
+ */
+static bool rvsGetROCmVersionStringFromRcmcore(std::string* out) {
+  unsigned int mj = 0, mn = 0, p = 0;
+  if (getROCmVersion(&mj, &mn, &p) != VerSuccess) {
+    return false;
+  }
+  std::ostringstream oss;
+  oss << mj << "." << mn << "." << p;
+  *out = oss.str();
+  return true;
+}
+#endif
 
 /*** Example rvs.conf file structure
 
@@ -248,14 +269,24 @@ void rvs::exec::in_progress_thread(exec_action action_info) {
 std::string getROCmVersion(void) {
 
   std::string line = "N/A";
-  std::ifstream inputFile("/opt/rocm/.info/version-rocm");
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
+  if (rvsGetROCmVersionStringFromRcmcore(&line)) {
+    return line;
+  }
+  return "N/A";
+#else
+  const std::string vfile = rvs_get_rocm_install_path_string() + "/.info/version-rocm";
+  std::ifstream inputFile(vfile);
   if (!inputFile) {
     return line;
   }
   std::getline(inputFile, line);
   inputFile.close();
-
+  if (line.empty()) {
+    line = "N/A";
+  }
   return line;
+#endif
 }
 
 /**

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -40,9 +40,7 @@
 #include "include/rvsaction.h"
 #include "include/rvsliblog.h"
 #include "include/rvsoptions.h"
-#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
-#include "rocm-core/rocm_getpath.h"
-#endif
+#include "include/rvs_util.h"
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -180,30 +178,8 @@ rvs::module* rvs::module::find_create_module(const char* name) {
       psolib = dlopen(sofullname.c_str(), RTLD_NOW);
       // error?
       if (!psolib) {
-        //Search libraries in RVS install path
-#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
-        char *installPath = nullptr;
-        unsigned int installPathLen = 0;
-        string rocmPath;
-        PathErrors_t retVal = PathSuccess;
-        // Get the ROCm install path
-        retVal = getROCmInstallPath( &installPath, &installPathLen );
-        if(retVal == PathSuccess){
-          rocmPath = installPath;
-        }
-        else {
-          std::cout << "Failed to get ROCm Install Path: " << retVal <<"\nSet ROCM_PATH in env" << std::endl;
-        }
-        // free allocated memory
-        if(installPath != nullptr) {
-          free(installPath);
-        }
-        libpath = rocmPath;
-        libpath += "/";
-        libpath += RVS_LIB_PATH;
-#else
-        libpath = RVS_LIB_PATH;
-#endif
+        // RVS module lib dir: from rvs binary, $RVS_PREFIX, or build-time RVS_LIB_PATH
+        libpath = rvs_get_rvs_modules_lib_dir_string();
         libpath += "/";
         string sofullname(libpath + it->second);
         psolib = dlopen(sofullname.c_str(), RTLD_NOW);

--- a/rvslib/CMakeLists.txt
+++ b/rvslib/CMakeLists.txt
@@ -174,7 +174,11 @@ set_target_properties(${RVS_TARGET}
  PROPERTIES SUFFIX .so.${LIB_VERSION_STRING}
  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 target_compile_options(${RVS_TARGET} PRIVATE -fopenmp)
-target_link_libraries(${RVS_TARGET} ${AMD_SMI_LIB} -fopenmp)
+if(FETCH_ROCMPATH_FROM_ROCMCORE)
+  target_link_libraries(${RVS_TARGET} ${AMD_SMI_LIB} ${ROCM_CORE} -fopenmp)
+else()
+  target_link_libraries(${RVS_TARGET} ${AMD_SMI_LIB} -fopenmp)
+endif()
 ## Install shared library librvslib.so
 add_custom_command(TARGET ${RVS_TARGET} POST_BUILD
 COMMAND ln -fs ./lib${RVS}.so.${LIB_VERSION_STRING} lib${RVS}.so.${VERSION_MAJOR} WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}

--- a/src/rvs_util.cpp
+++ b/src/rvs_util.cpp
@@ -25,9 +25,17 @@
 #include "include/rvs_util.h"
 #include <vector>
 #include <string>
+#include <cstdlib>
+#include <cstring>
 #include <regex>
+#if defined(__linux__)
+#include <unistd.h>
+#endif
 #include <iomanip>
 #include <algorithm>
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
+#include "rocm-core/rocm_getpath.h"
+#endif
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime_api.h"
 #include "amd_smi/amdsmi.h"
@@ -335,5 +343,127 @@ std::string get_gpu_name (void) {
   rvs::gpulist::Initialize();
 
   return rvs::gpulist::gpu_get_platform_name () ;
+}
+
+std::string rvs_get_rocm_install_path_string(void) {
+#ifdef FETCH_ROCMPATH_FROM_ROCMCORE
+  char* installPath = nullptr;
+  unsigned int installPathLen = 0;
+  PathErrors_t perr = getROCmInstallPath(&installPath, &installPathLen);
+  if (perr == PathSuccess && installPath != nullptr) {
+    std::string s(installPath);
+    free(installPath);
+    if (!s.empty()) {
+      return s;
+    }
+  } else if (installPath != nullptr) {
+    free(installPath);
+  }
+#endif
+  if (const char* env = std::getenv("ROCM_PATH")) {
+    if (env[0] != '\0') {
+      return std::string(env);
+    }
+  }
+  return std::string(ROCM_PATH);
+}
+
+namespace {
+
+std::string rvs_strip_trailing_slashes(std::string s) {
+  while (s.size() > 1 && s.back() == '/') {
+    s.pop_back();
+  }
+  return s;
+}
+
+std::string rvs_path_dirname(const std::string& path) {
+  if (path.empty()) {
+    return path;
+  }
+  size_t end = path.size();
+  while (end > 1 && path[end - 1] == '/') {
+    --end;
+  }
+  const size_t pos = path.rfind('/', end - 1);
+  if (pos == std::string::npos) {
+    return ".";
+  }
+  if (pos == 0) {
+    return std::string("/");
+  }
+  return path.substr(0, pos);
+}
+
+std::string rvs_path_basename(const std::string& path) {
+  if (path.empty()) {
+    return path;
+  }
+  size_t end = path.size();
+  while (end > 0 && path[end - 1] == '/') {
+    --end;
+  }
+  if (end == 0) {
+    return std::string();
+  }
+  const size_t start = path.rfind('/', end - 1);
+  if (start == std::string::npos) {
+    return path.substr(0, end);
+  }
+  return path.substr(start + 1, end - start - 1);
+}
+
+#if defined(__linux__)
+std::string rvs_linux_resolved_exe_path() {
+  char linkbuf[4096] = {0};
+  const ssize_t n = readlink("/proc/self/exe", linkbuf, sizeof(linkbuf) - 1);
+  if (n <= 0) {
+    return std::string();
+  }
+  linkbuf[n] = '\0';
+  char resolved[4096] = {0};
+  if (realpath(linkbuf, resolved) != nullptr) {
+    return std::string(resolved);
+  }
+  return std::string(linkbuf);
+}
+#endif
+
+std::string rvs_rvs_prefix_from_rvs_process() {
+  if (const char* pfx = std::getenv("RVS_PREFIX")) {
+    if (pfx[0] != '\0') {
+      return rvs_strip_trailing_slashes(std::string(pfx));
+    }
+  }
+#if defined(__linux__)
+  const std::string exe = rvs_linux_resolved_exe_path();
+  if (exe.empty() || rvs_path_basename(exe) != "rvs") {
+    return std::string();
+  }
+  const std::string bindir = rvs_path_dirname(exe);
+  const std::string binname = rvs_path_basename(bindir);
+  if (binname == "bin" || binname == "sbin") {
+    return rvs_path_dirname(bindir);
+  }
+#endif
+  return std::string();
+}
+
+}  // namespace
+
+std::string rvs_get_rvs_data_root_string(void) {
+  const std::string pfx = rvs_rvs_prefix_from_rvs_process();
+  if (!pfx.empty()) {
+    return pfx + std::string("/") + RVS_RELPATH_DATA_DIR;
+  }
+  return std::string(RVS_DATA_ROOT);
+}
+
+std::string rvs_get_rvs_modules_lib_dir_string(void) {
+  const std::string pfx = rvs_rvs_prefix_from_rvs_process();
+  if (!pfx.empty()) {
+    return pfx + std::string("/") + RVS_RELPATH_MODULE_LIB_DIR;
+  }
+  return std::string(RVS_LIB_PATH);
 }
 


### PR DESCRIPTION
## Motivation

RVS prints ROCm varsion it links/loads.Undate the version fetch using API provided by ROCm.If that option is turned OFF fallback to ROCM_PATH environment variable.

For all the module/config reading inside RVS, use self discovery of RVS location(linux only) and use path relative to executable This is to ensure relocation of RVS possible.

For both ROCm path & RVS path last choice will be to use compile time backed in path.
