### PR TITLE
Update install instruction, RPATH for RVS.

### DIFF
--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -346,16 +346,69 @@ sudo rpm -i --replacefiles --nodeps amdrocm7-rvs-*.rpm
 
 ### Any Linux Distribution (TGZ - Relocatable)
 
+#### Pre-install: ROCm
+
+Before you install the RVS TGZ, **ROCm must be installed, configured, and on your `PATH` / `LD_LIBRARY_PATH` as in AMD’s documentation** so HIP, HSA, and other ROCm libraries are discoverable. Follow the current Linux install guide in **rocm docs**:
+
+- **ROCm documentation (start here)**: <https://rocm.docs.amd.com/>
+- **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/en/latest/deploy/linux/index.html>
+
+**Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm/LLVM libraries. The TGZ only ships RVS; it does not replace a full ROCm stack.
+
+#### Install RVS run-time dependencies (on the target system)
+
+The TGZ is built against ROCm, but the host still needs a few system libraries. Install at least **PCI (libpci)** and an **OpenMP runtime**; exact package names differ by family:
+
+| Family | Typical packages |
+|--------|------------------|
+| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0` on some releases) — PCI access; for OpenMP use the distro’s `libgomp1` and/or an LLVM **libomp** runtime (e.g. `libomp5` / `libllvm-*` depending on the release; match your `apt` search for `libomp` / `libgomp`). |
+| **RHEL / CentOS / Rocky / Alma (dnf/yum)** | `pciutils-libs` (provides `libpci`); for OpenMP: `libgomp` (GCC) and/or `libomp` if provided in the repo. |
+| **SUSE / openSUSE (zypper)** | `libpci3` and `pciutils` as needed; OpenMP: `libgomp1` and/or a `libllvm-openmp*`-style package, depending on the release. |
+
+Examples (adjust package versions to your release):
+
 ```bash
-# Extract to the extras directory
+# Ubuntu / Debian
+sudo apt update
+sudo apt install -y libpci3 libgomp1
+
+# RHEL / Rocky / Alma 8+ (DNF)
+sudo dnf install -y pciutils-libs libgomp
+# if available in your repo:
+# sudo dnf install -y libomp
+
+# openSUSE / SUSE (zypper)
+sudo zypper install libpci3 libgomp1
+```
+
+**Note:** RVS is often linked to **LLVM OpenMP** (`libomp`) from the ROCm toolchain. If the dynamic linker cannot find `libomp.so` after the steps below, that library may already be present under the **ROCm installation’s LLVM** tree (see post-install). Install host packages only where you still need a system copy.
+
+#### Extract the TGZ
+
+```bash
+# Extract to the extras directory (example for ROCm major 7; match your path)
 sudo mkdir -p /opt/rocm/extras-7
 sudo tar -xzf amdrocm7-rvs-*.tar.gz -C /opt/rocm/extras-7
+```
 
-# Setup environment
-export PATH=/opt/rocm/extras-7/bin:$PATH
-export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:$LD_LIBRARY_PATH
+#### Post-install: `PATH` and `LD_LIBRARY_PATH`
 
-# Run RVS
+Point the shell at the extracted RVS prefix and the ROCm you installed (replace paths with your real `ROCM_PATH` and extras major version). Copy and paste the block as one unit:
+
+```bash
+export ROCM_PATH=/opt/rocm              # or your real ROCm root, per rocm docs
+export PATH=/opt/rocm/extras-7/bin:$ROCM_PATH/bin:$PATH
+export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:\
+$ROCM_PATH/lib:\
+$ROCM_PATH/lib/llvm/lib:\
+$LD_LIBRARY_PATH
+```
+
+**`libomp` (LLVM OpenMP):** `$ROCM_PATH/lib/llvm/lib` is already in the `export` block above: **`libomp.so` is often there** (ROCm’s LLVM), not only from the host distro. If your layout differs, run `find $ROCM_PATH -name 'libomp.so' 2>/dev/null` and point `LD_LIBRARY_PATH` at the directory you find. `rvs` also has rpath relative to its install; you may still need a host `libomp` or `libgomp` package. If you still get `libomp.so: cannot open shared object` from the dynamic linker, change the LLVM path for your ROCm version or add packages from the prerequisite section.
+
+**Run RVS**
+
+```bash
 rvs --help
 ```
 

--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -351,7 +351,7 @@ sudo rpm -i --replacefiles --nodeps amdrocm7-rvs-*.rpm
 Before you install the RVS TGZ, **ROCm must be installed, configured, and on your `PATH` / `LD_LIBRARY_PATH` as in AMD’s documentation** so HIP, HSA, and other ROCm libraries are discoverable. Follow the current Linux install guide in **rocm docs**:
 
 - **ROCm documentation (start here)**: <https://rocm.docs.amd.com/>
-- **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/en/latest/deploy/linux/index.html>
+- **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/en/latest/install/rocm.html>
 
 **Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm/LLVM libraries. The TGZ only ships RVS; it does not replace a full ROCm stack.
 

--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -351,37 +351,35 @@ sudo rpm -i --replacefiles --nodeps amdrocm7-rvs-*.rpm
 Before you install the RVS TGZ, **ROCm must be installed, configured, and on your `PATH` / `LD_LIBRARY_PATH` as in AMD’s documentation** so HIP, HSA, and other ROCm libraries are discoverable. Follow the current Linux install guide in **rocm docs**:
 
 - **ROCm documentation (start here)**: <https://rocm.docs.amd.com/>
-- **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/en/latest/install/rocm.html>
+- **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>
 
 **Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm/LLVM libraries. The TGZ only ships RVS; it does not replace a full ROCm stack.
 
 #### Install RVS run-time dependencies (on the target system)
 
-The TGZ is built against ROCm, but the host still needs a few system libraries. Install at least **PCI (libpci)** and an **OpenMP runtime**; exact package names differ by family:
+The TGZ is built against ROCm, but the host still needs a few system libraries. Install at least **PCI (libpci)** and **LLVM OpenMP** (**`libomp.so`**).
 
-| Family | Typical packages |
-|--------|------------------|
-| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0` on some releases) — PCI access; for OpenMP use the distro’s `libgomp1` and/or an LLVM **libomp** runtime (e.g. `libomp5` / `libllvm-*` depending on the release; match your `apt` search for `libomp` / `libgomp`). |
-| **RHEL / CentOS / Rocky / Alma (dnf/yum)** | `pciutils-libs` (provides `libpci`); for OpenMP: `libgomp` (GCC) and/or `libomp` if provided in the repo. |
-| **SUSE / openSUSE (zypper)** | `libpci3` and `pciutils` as needed; OpenMP: `libgomp1` and/or a `libllvm-openmp*`-style package, depending on the release. |
+| Family | PCI | LLVM OpenMP (`libomp.so`) |
+|--------|-----|---------------------------|
+| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0`) | **`libomp5`** on many releases (`apt search '^libomp'`). |
+| **RHEL / Rocky / Alma 8+** | `pciutils-libs` | **`libomp`** (LLVM OpenMP for Clang, **AppStream**). |
+| **SUSE / openSUSE** | `libpci3`, `pciutils` as needed | **Versioned** packages, e.g. **`libomp18`**, **`libomp17`** — use **`zypper search -s libomp`** and install the **runtime** package for your release (names differ between Leap, SLE, and Tumbleweed). |
 
-Examples (adjust package versions to your release):
+Examples:
 
 ```bash
 # Ubuntu / Debian
 sudo apt update
-sudo apt install -y libpci3 libgomp1
+sudo apt install -y libpci3 libomp5
 
-# RHEL / Rocky / Alma 8+ (DNF)
-sudo dnf install -y pciutils-libs libgomp
-# if available in your repo:
-# sudo dnf install -y libomp
+# RHEL / Rocky / Alma 8+
+sudo dnf install -y pciutils-libs libomp
 
-# openSUSE / SUSE (zypper)
-sudo zypper install libpci3 libgomp1
+# openSUSE (example package name for Tumbleweed; adjust after zypper search)
+sudo zypper install libpci3 libomp18
 ```
 
-**Note:** RVS is often linked to **LLVM OpenMP** (`libomp`) from the ROCm toolchain. If the dynamic linker cannot find `libomp.so` after the steps below, that library may already be present under the **ROCm installation’s LLVM** tree (see post-install). Install host packages only where you still need a system copy.
+**Note:** Prefer **`libomp.so`** from **ROCm** when possible; host **`libomp`** packages are for when the linker still cannot find the library after setting `LD_LIBRARY_PATH`.
 
 #### Extract the TGZ
 
@@ -404,7 +402,7 @@ $ROCM_PATH/lib/llvm/lib:\
 $LD_LIBRARY_PATH
 ```
 
-**`libomp` (LLVM OpenMP):** `$ROCM_PATH/lib/llvm/lib` is already in the `export` block above: **`libomp.so` is often there** (ROCm’s LLVM), not only from the host distro. If your layout differs, run `find $ROCM_PATH -name 'libomp.so' 2>/dev/null` and point `LD_LIBRARY_PATH` at the directory you find. `rvs` also has rpath relative to its install; you may still need a host `libomp` or `libgomp` package. If you still get `libomp.so: cannot open shared object` from the dynamic linker, change the LLVM path for your ROCm version or add packages from the prerequisite section.
+**`libomp` (LLVM OpenMP):** `$ROCM_PATH/lib/llvm/lib` is already in the `export` block above. If **`libomp.so`** is still missing, use `find $ROCM_PATH -name 'libomp.so'` or install host **`libomp`** packages from the table above.
 
 **Run RVS**
 

--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -62,7 +62,7 @@ GitHub Actions Workflow
     │   ├── export CPACK_RPM_PACKAGE_RELEASE (same as DEB)
     │   ├── export CMAKE_CXX_COMPILER=hipcc (AlmaLinux only)
     │   └── export CMAKE_COMMAND=cmake3 (AlmaLinux) or cmake (Ubuntu)
-    ├── 4. Configure CMake with Relocatable RPATH
+    ├── 4. Configure CMake (install RPATH defaults live in CMakeLists.txt)
     │   └── $CMAKE_COMMAND -B ./build \
     │         -DCMAKE_BUILD_TYPE=Release \
     │         -DROCM_PATH=$ROCM_PATH \
@@ -71,9 +71,6 @@ GitHub Actions Workflow
     │         -DROCM_MAJOR_VERSION=$ROCM_MAJOR \
     │         -DCMAKE_INSTALL_PREFIX=/opt/rocm/extras-$ROCM_MAJOR \
     │         -DCPACK_PACKAGING_INSTALL_PREFIX=/opt/rocm/extras-$ROCM_MAJOR \
-    │         -DCMAKE_SKIP_RPATH=FALSE \
-    │         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
-    │         -DCMAKE_INSTALL_RPATH="$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/extras-$ROCM_MAJOR/lib" \
     │         -DCMAKE_VERBOSE_MAKEFILE=1 \
     │         -DFETCH_ROCMPATH_FROM_ROCMCORE=ON
     ├── 5. Build RVS
@@ -85,10 +82,10 @@ GitHub Actions Workflow
 
 ### Key Technical Details
 
-**Relocatable RPATH**: The `$ORIGIN` relative RPATH ensures binaries can find their libraries regardless of installation location:
+**Relocatable RPATH**: Defaults are set in **`CMakeLists.txt`** (`CMAKE_INSTALL_RPATH`, **`CMAKE_BUILD_RPATH`** (same list for the build tree), `CMAKE_SKIP_RPATH`, `CMAKE_INSTALL_RPATH_USE_LINK_PATH`). **`CMAKE_*_LINKER_FLAGS_INIT`** only adds **`--enable-new-dtags`** (RUNPATH behavior), not a second copy of **`$ORIGIN`**. On **GitHub Actions** (`GITHUB_ACTIONS=true`), **`CMAKE_SKIP_BUILD_RPATH`** is set so build-tree binaries do not pick up extra RPATH entries from the CI ROCm SDK path (e.g. **`.../rocm-sdk/install/lib/llvm/lib`**); **install/CPack** still use **`CMAKE_INSTALL_RPATH`**. The **`$ORIGIN`** relative entries resolve to the install prefix (`.../extras-<N>/bin` → `.../extras-<N>/lib`), so **`/opt/rocm/extras-<N>/lib` is not duplicated** in the list. Absolute paths add **`/opt/rocm/lib`**, **`/opt/rocm/core-<ROCM_MAJOR>/lib`**, and **`/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib`** — equivalent to:
 
 ```bash
-CMAKE_INSTALL_RPATH="$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/extras-<ROCM_MAJOR>/lib"
+CMAKE_INSTALL_RPATH="$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/core-<ROCM_MAJOR>/lib:/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib"
 ```
 
 **Automatic Version Management**: CMake reads the project version from `CMakeLists.txt` and CPack uses it for package naming automatically. The **patch version** is auto-computed at CMake configure time: `git describe --tags --match "v<major>.<minor>.*"` counts commits since the last matching `v` tag. For example, if the tag is `v1.3.0` and there have been 15 commits since, the package version becomes `1.3.15`. If no matching tag exists or git is unavailable, the patch defaults to `0` from `CMakeLists.txt`. This works for both CI builds and direct local `cmake` invocations.
@@ -103,7 +100,7 @@ CMAKE_INSTALL_RPATH="$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/extras-
 
 **Dynamic ROCm Path Discovery**: `FETCH_ROCMPATH_FROM_ROCMCORE=ON` allows RVS to automatically detect ROCm installation location at runtime from ROCm core libraries.
 
-**Single Source of Truth**: All build logic resides in `build_packages_local.sh`, which can be used for both local builds and CI/CD.
+**Single Source of Truth**: `build_packages_local.sh` drives configure/build/package for CI and local use; **RPATH defaults** live in **`CMakeLists.txt`** so a plain **`cmake`** invocation gets the same install **`RPATH`** without copying flags into the shell script.
 
 ### Workflow Steps
 
@@ -353,33 +350,30 @@ Before you install the RVS TGZ, **ROCm must be installed, configured, and on you
 - **ROCm documentation (start here)**: <https://rocm.docs.amd.com/>
 - **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/>
 
-**Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm/LLVM libraries. The TGZ only ships RVS; it does not replace a full ROCm stack.
+**Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm libraries. Install a ROCm stack that includes **ROCm’s LLVM** (for example the **`rocm-llvm`** package from the ROCm repo). **DEB/RPM** packages from this project declare that dependency; TGZ users should mirror that on the host. The TGZ only ships RVS; it does not replace a full ROCm stack.
 
 #### Install RVS run-time dependencies (on the target system)
 
-The TGZ is built against ROCm, but the host still needs a few system libraries. Install at least **PCI (libpci)** and **LLVM OpenMP** (**`libomp.so`**).
+The TGZ is built against ROCm; on the target host you still need **PCI** for GPU enumeration:
 
-| Family | PCI | LLVM OpenMP (`libomp.so`) |
-|--------|-----|---------------------------|
-| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0`) | **`libomp5`** on many releases (`apt search '^libomp'`). |
-| **RHEL / Rocky / Alma 8+** | `pciutils-libs` | **`libomp`** (LLVM OpenMP for Clang, **AppStream**). |
-| **SUSE / openSUSE** | `libpci3`, `pciutils` as needed | **Versioned** packages, e.g. **`libomp18`**, **`libomp17`** — use **`zypper search -s libomp`** and install the **runtime** package for your release (names differ between Leap, SLE, and Tumbleweed). |
-
-Examples:
+| Family | Typical PCI package |
+|--------|---------------------|
+| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0` on some releases) |
+| **RHEL / Rocky / Alma 8+** | `pciutils-libs` |
+| **SUSE / openSUSE** | `libpci3` / `pciutils` as appropriate for the release |
 
 ```bash
 # Ubuntu / Debian
-sudo apt update
-sudo apt install -y libpci3 libomp5
+sudo apt update && sudo apt install -y libpci3
 
 # RHEL / Rocky / Alma 8+
-sudo dnf install -y pciutils-libs libomp
+sudo dnf install -y pciutils-libs
 
-# openSUSE (example package name for Tumbleweed; adjust after zypper search)
-sudo zypper install libpci3 libomp18
+# openSUSE / SUSE (adjust package names per release)
+sudo zypper install libpci3
 ```
 
-**Note:** Prefer **`libomp.so`** from **ROCm** when possible; host **`libomp`** packages are for when the linker still cannot find the library after setting `LD_LIBRARY_PATH`.
+User-facing install steps for TGZ (PATH / `LD_LIBRARY_PATH`, **`RPATH`** including **`/opt/rocm/lib`**, **`/opt/rocm/core-<major>/lib`**, and **`/opt/rocm/core-<major>/lib/llvm/lib`**) are in **[docs/INSTALL_TGZ.md](../../docs/INSTALL_TGZ.md)**.
 
 #### Extract the TGZ
 
@@ -396,13 +390,10 @@ Point the shell at the extracted RVS prefix and the ROCm you installed (replace 
 ```bash
 export ROCM_PATH=/opt/rocm              # or your real ROCm root, per rocm docs
 export PATH=/opt/rocm/extras-7/bin:$ROCM_PATH/bin:$PATH
-export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:\
-$ROCM_PATH/lib:\
-$ROCM_PATH/lib/llvm/lib:\
-$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:$ROCM_PATH/lib:$ROCM_PATH/lib/llvm/lib:$LD_LIBRARY_PATH
 ```
 
-**`libomp` (LLVM OpenMP):** `$ROCM_PATH/lib/llvm/lib` is already in the `export` block above. If **`libomp.so`** is still missing, use `find $ROCM_PATH -name 'libomp.so'` or install host **`libomp`** packages from the table above.
+**`rvs`** embeds **`RPATH`** for those paths, so it usually does not need **`LD_LIBRARY_PATH`** for them. The export still includes **`$ROCM_PATH/lib/llvm/lib`** for a typical ROCm tree, other tools, and troubleshooting; if LLVM is only under **`$ROCM_PATH/core-<major>/lib/llvm/lib`**, add that path instead or as well.
 
 **Run RVS**
 
@@ -521,7 +512,7 @@ Note: You may need to update the OS detection logic in `build_packages_local.sh`
 
 ### Customizing Build Parameters
 
-Edit the CMake configuration section in `build_packages_local.sh`:
+Edit the CMake arguments in `build_packages_local.sh`, or override **`CMAKE_INSTALL_RPATH`** / **`CMAKE_SKIP_RPATH`** from the command line when needed. Defaults match packaged builds:
 
 ```bash
 cmake -B "$BUILD_DIR" \
@@ -531,10 +522,6 @@ cmake -B "$BUILD_DIR" \
     -DROCM_MAJOR_VERSION="$ROCM_MAJOR" \
     -DCMAKE_INSTALL_PREFIX="/opt/rocm/extras-${ROCM_MAJOR}" \
     -DCPACK_PACKAGING_INSTALL_PREFIX="/opt/rocm/extras-${ROCM_MAJOR}" \
-    -DCMAKE_SKIP_RPATH=FALSE \
-    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE \
-    -DCMAKE_INSTALL_RPATH="\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../lib/rvs:/opt/rocm/extras-${ROCM_MAJOR}/lib" \
-    -DRPATH_MODE=OFF \
     -DCMAKE_VERBOSE_MAKEFILE=1 \
     -DFETCH_ROCMPATH_FROM_ROCMCORE=ON \
     -DYOUR_CUSTOM_OPTION=ON  # Add custom options here
@@ -563,7 +550,7 @@ If binaries can't find libraries:
 # Check RPATH settings (replace 7 with your ROCm major version)
 readelf -d /opt/rocm/extras-7/bin/rvs | grep RPATH
 
-# Should show: $ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/extras-7/lib
+# Should include: $ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/core-7/lib:/opt/rocm/core-7/lib/llvm/lib
 ```
 
 ### Missing Dependencies

--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -82,10 +82,10 @@ GitHub Actions Workflow
 
 ### Key Technical Details
 
-**Relocatable RPATH**: Defaults are set in **`CMakeLists.txt`** (`CMAKE_INSTALL_RPATH`, **`CMAKE_BUILD_RPATH`** (same list for the build tree), `CMAKE_SKIP_RPATH`, `CMAKE_INSTALL_RPATH_USE_LINK_PATH`). **`CMAKE_*_LINKER_FLAGS_INIT`** only adds **`--enable-new-dtags`** (RUNPATH behavior), not a second copy of **`$ORIGIN`**. On **GitHub Actions** (`GITHUB_ACTIONS=true`), **`CMAKE_SKIP_BUILD_RPATH`** is set so build-tree binaries do not pick up extra RPATH entries from the CI ROCm SDK path (e.g. **`.../rocm-sdk/install/lib/llvm/lib`**); **install/CPack** still use **`CMAKE_INSTALL_RPATH`**. The **`$ORIGIN`** relative entries resolve to the install prefix (`.../extras-<N>/bin` → `.../extras-<N>/lib`), so **`/opt/rocm/extras-<N>/lib` is not duplicated** in the list. Absolute paths add **`/opt/rocm/lib`**, **`/opt/rocm/core-<ROCM_MAJOR>/lib`**, and **`/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib`** — equivalent to:
+**Relocatable RPATH**: Defaults are set in **`CMakeLists.txt`** (`CMAKE_INSTALL_RPATH`, **`CMAKE_BUILD_RPATH`** (same list for the build tree), `CMAKE_SKIP_RPATH`, `CMAKE_INSTALL_RPATH_USE_LINK_PATH`). **`CMAKE_*_LINKER_FLAGS_INIT`** only adds **`--enable-new-dtags`** (RUNPATH behavior), not a second copy of **`$ORIGIN`**. On **GitHub Actions** (`GITHUB_ACTIONS=true`), **`CMAKE_SKIP_BUILD_RPATH`** applies when using **CMake 3.9+**, and **`CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH`** (strip implicit SDK paths on install) when using **CMake 3.16+**. The **`$ORIGIN`** relative entries resolve to the install prefix (`.../extras-<N>/bin` → `.../extras-<N>/lib`), so **`/opt/rocm/extras-<N>/lib` is not duplicated** in the list. Absolute paths add **`/opt/rocm/lib`**, **`/opt/rocm/lib/llvm/lib`** (older ROCm layouts), **`/opt/rocm/core-<ROCM_MAJOR>/lib`**, and **`/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib`** — equivalent to:
 
 ```bash
-CMAKE_INSTALL_RPATH="$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/core-<ROCM_MAJOR>/lib:/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib"
+CMAKE_INSTALL_RPATH="$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-<ROCM_MAJOR>/lib:/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib"
 ```
 
 **Automatic Version Management**: CMake reads the project version from `CMakeLists.txt` and CPack uses it for package naming automatically. The **patch version** is auto-computed at CMake configure time: `git describe --tags --match "v<major>.<minor>.*"` counts commits since the last matching `v` tag. For example, if the tag is `v1.3.0` and there have been 15 commits since, the package version becomes `1.3.15`. If no matching tag exists or git is unavailable, the patch defaults to `0` from `CMakeLists.txt`. This works for both CI builds and direct local `cmake` invocations.
@@ -373,7 +373,7 @@ sudo dnf install -y pciutils-libs
 sudo zypper install libpci3
 ```
 
-User-facing install steps for TGZ (PATH / `LD_LIBRARY_PATH`, **`RPATH`** including **`/opt/rocm/lib`**, **`/opt/rocm/core-<major>/lib`**, and **`/opt/rocm/core-<major>/lib/llvm/lib`**) are in **[docs/INSTALL_TGZ.md](../../docs/INSTALL_TGZ.md)**.
+User-facing install steps for TGZ (PATH / `LD_LIBRARY_PATH`, **`RPATH`** including **`/opt/rocm/lib`**, **`/opt/rocm/lib/llvm/lib`**, **`/opt/rocm/core-<major>/lib`**, and **`/opt/rocm/core-<major>/lib/llvm/lib`**) are in **[docs/INSTALL_TGZ.md](../../docs/INSTALL_TGZ.md)**.
 
 #### Extract the TGZ
 
@@ -393,7 +393,7 @@ export PATH=/opt/rocm/extras-7/bin:$ROCM_PATH/bin:$PATH
 export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:$ROCM_PATH/lib:$ROCM_PATH/lib/llvm/lib:$LD_LIBRARY_PATH
 ```
 
-**`rvs`** embeds **`RPATH`** for those paths, so it usually does not need **`LD_LIBRARY_PATH`** for them. The export still includes **`$ROCM_PATH/lib/llvm/lib`** for a typical ROCm tree, other tools, and troubleshooting; if LLVM is only under **`$ROCM_PATH/core-<major>/lib/llvm/lib`**, add that path instead or as well.
+**`rvs`** embeds **`RPATH`** for **`/opt/rocm/lib`**, **`/opt/rocm/lib/llvm/lib`**, **`core-<major>`** paths, and the extras-relative **`$ORIGIN`** paths, so it usually does not need **`LD_LIBRARY_PATH`** for them. The export still includes **`$ROCM_PATH/lib/llvm/lib`** for a typical ROCm tree, other tools, and troubleshooting; if LLVM is only under **`$ROCM_PATH/core-<major>/lib/llvm/lib`**, add that path instead or as well.
 
 **Run RVS**
 
@@ -550,7 +550,7 @@ If binaries can't find libraries:
 # Check RPATH settings (replace 7 with your ROCm major version)
 readelf -d /opt/rocm/extras-7/bin/rvs | grep RPATH
 
-# Should include: $ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/core-7/lib:/opt/rocm/core-7/lib/llvm/lib
+# Should include: $ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-7/lib:/opt/rocm/core-7/lib/llvm/lib
 ```
 
 ### Missing Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,17 +203,24 @@ list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}")
 set(CMAKE_SKIP_RPATH FALSE CACHE BOOL "Skip RPATH for build targets")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE CACHE BOOL "Append link paths to install RPATH")
 set(CMAKE_INSTALL_RPATH
-  "\$ORIGIN;\$ORIGIN/../lib;\$ORIGIN/../lib/rvs;/opt/rocm/lib;/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib;/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib"
+  "\$ORIGIN;\$ORIGIN/../lib;\$ORIGIN/../lib/rvs;/opt/rocm/lib;/opt/rocm/lib/llvm/lib;/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib;/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib"
   CACHE STRING "RPATH for installed RVS binaries and modules")
 set(CMAKE_BUILD_RPATH "${CMAKE_INSTALL_RPATH}")
 
-# CI (GitHub Actions) uses a relocatable ROCm SDK under e.g. $HOME/rocm-sdk/install; the linker
-# can still record those directories in build-tree binaries. Skip CMake's build RPATH there only —
-# local builds keep CMAKE_BUILD_RPATH so uninstalled binaries/tests resolve libs. Install/CPack
-# still apply CMAKE_INSTALL_RPATH (requires CMake 3.9+ for CMAKE_SKIP_BUILD_RPATH).
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
-  if("$ENV{GITHUB_ACTIONS}" STREQUAL "true")
-    set(CMAKE_SKIP_BUILD_RPATH TRUE CACHE BOOL "On GitHub Actions, skip build-tree RPATH (avoid embedding CI SDK paths)")
+# CI (GitHub Actions): GITHUB_ACTIONS flags below need CMake 3.9+ / 3.16+ at configure time.
+if("$ENV{GITHUB_ACTIONS}" STREQUAL "true")
+  message(STATUS "RVS RPATH (GitHub Actions): CMake ${CMAKE_VERSION}")
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
+    set(CMAKE_SKIP_BUILD_RPATH TRUE CACHE BOOL "On GitHub Actions, skip CMake build-tree RPATH")
+    message(STATUS "RVS RPATH (GitHub Actions): CMAKE_SKIP_BUILD_RPATH=${CMAKE_SKIP_BUILD_RPATH}")
+  else()
+    message(STATUS "RVS RPATH (GitHub Actions): CMAKE_SKIP_BUILD_RPATH not applied (need CMake 3.9+)")
+  endif()
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.16")
+    set(CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH TRUE CACHE BOOL "On GitHub Actions, strip implicit link-dir RPATH on install")
+    message(STATUS "RVS RPATH (GitHub Actions): CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH=${CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH}")
+  else()
+    message(STATUS "RVS RPATH (GitHub Actions): CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH not applied (need CMake 3.16+)")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,9 @@
 ################################################################################
 
 cmake_minimum_required ( VERSION 3.5.0 )
-set(CMAKE_SHARED_LINKER_FLAGS_INIT "-Wl,--enable-new-dtags,--rpath,$ORIGIN:$ORIGIN/.." CACHE STRING "RUNPATH for libraries")
-set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--enable-new-dtags,--rpath,$ORIGIN/../lib" CACHE STRING "RUNPATH for executables")
+# Prefer RUNPATH (DT_RUNPATH); do not embed $ORIGIN here — CMAKE_BUILD_RPATH / CMAKE_INSTALL_RPATH below are the single source of truth.
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "-Wl,--enable-new-dtags" CACHE STRING "Shared linker flags")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--enable-new-dtags" CACHE STRING "Executable linker flags")
 
 set( COMP_TYPE "applications" )
 set( BUILD_ENABLE_LINTIAN_OVERRIDES ON CACHE BOOL "Enable/Disable Lintian Overrides" )
@@ -197,6 +198,25 @@ set(CMAKE_INSTALL_PREFIX "/opt/rocm/extras-${ROCM_MAJOR_VERSION}" CACHE PATH "CM
 set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm/extras-${ROCM_MAJOR_VERSION}" CACHE PATH "Prefix used in built packages")
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}")
 
+# RPATH (build tree + install): one list — avoids duplicating $ORIGIN paths that previously
+# appeared in both CMAKE_*_LINKER_FLAGS_INIT and CMAKE_INSTALL_RPATH.
+set(CMAKE_SKIP_RPATH FALSE CACHE BOOL "Skip RPATH for build targets")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE CACHE BOOL "Append link paths to install RPATH")
+set(CMAKE_INSTALL_RPATH
+  "\$ORIGIN;\$ORIGIN/../lib;\$ORIGIN/../lib/rvs;/opt/rocm/lib;/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib;/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib"
+  CACHE STRING "RPATH for installed RVS binaries and modules")
+set(CMAKE_BUILD_RPATH "${CMAKE_INSTALL_RPATH}")
+
+# CI (GitHub Actions) uses a relocatable ROCm SDK under e.g. $HOME/rocm-sdk/install; the linker
+# can still record those directories in build-tree binaries. Skip CMake's build RPATH there only —
+# local builds keep CMAKE_BUILD_RPATH so uninstalled binaries/tests resolve libs. Install/CPack
+# still apply CMAKE_INSTALL_RPATH (requires CMake 3.9+ for CMAKE_SKIP_BUILD_RPATH).
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.9")
+  if("$ENV{GITHUB_ACTIONS}" STREQUAL "true")
+    set(CMAKE_SKIP_BUILD_RPATH TRUE CACHE BOOL "On GitHub Actions, skip build-tree RPATH (avoid embedding CI SDK paths)")
+  endif()
+endif()
+
 # Compile-time default used by rvs_get_rocm_install_path_string() after
 # getROCmInstallPath (if FETCH_*) and $ROCM_PATH env are considered.
 add_definitions(-DROCM_PATH="${ROCM_PATH}")
@@ -294,8 +314,9 @@ set(CPACK_PACKAGE_CONTACT "${PKG_MAINTAINER_NM} <${PKG_MAINTAINER_EMAIL}>")
 
 # Package dependencies: support both legacy (ROCm <=6.x) and new amdrocm-* naming (TheRock/ROCm 8.x per RFC0009)
 # DEB uses "old | new" OR syntax, RPM uses "(old or new)" boolean dependency syntax
-set(ROCM_DEB_DEPS "hip-runtime-amd | amdrocm-runtimes, comgr | amdrocm-runtimes, hsa-rocr | amdrocm-runtimes, rocblas | amdrocm-blas, amd-smi-lib | amdrocm-amdsmi, hiprand | amdrocm-rand, hipblaslt | amdrocm-blas")
-set(ROCM_RPM_DEPS "(hip-runtime-amd or amdrocm-runtimes), (comgr or amdrocm-runtimes), (hsa-rocr or amdrocm-runtimes), (rocblas or amdrocm-blas), (amd-smi-lib or amdrocm-amdsmi), (hiprand or amdrocm-rand), (hipblaslt or amdrocm-blas)")
+# rocm-llvm: ROCm LLVM (includes libomp used by HIP/RVS); pull OpenMP runtime from the ROCm stack, not host libgomp.
+set(ROCM_DEB_DEPS "hip-runtime-amd | amdrocm-runtimes, comgr | amdrocm-runtimes, hsa-rocr | amdrocm-runtimes, rocblas | amdrocm-blas, amd-smi-lib | amdrocm-amdsmi, hiprand | amdrocm-rand, hipblaslt | amdrocm-blas, rocm-llvm | amdrocm-llvm")
+set(ROCM_RPM_DEPS "(hip-runtime-amd or amdrocm-runtimes), (comgr or amdrocm-runtimes), (hsa-rocr or amdrocm-runtimes), (rocblas or amdrocm-blas), (amd-smi-lib or amdrocm-amdsmi), (hiprand or amdrocm-rand), (hipblaslt or amdrocm-blas), (rocm-llvm or amdrocm-llvm)")
 if(FETCH_ROCMPATH_FROM_ROCMCORE)
   set(ROCM_DEB_DEPS "${ROCM_DEB_DEPS}, ${ROCM_CORE} | amdrocm-base")
   set(ROCM_RPM_DEPS "${ROCM_RPM_DEPS}, (${ROCM_CORE} or amdrocm-base)")

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -545,8 +545,8 @@ if [ -d "$BUILD_DIR" ]; then
     rm -rf "$BUILD_DIR"
 fi
 
-# Build cmake command with optional CXX compiler
-# TODO: May be cleanup RPATH later with lesser options.
+# Build cmake command with optional CXX compiler.
+# CMAKE_INSTALL_RPATH / CMAKE_SKIP_RPATH / CMAKE_INSTALL_RPATH_USE_LINK_PATH live in CMakeLists.txt.
 CMAKE_ARGS=(
     -B "$BUILD_DIR"
     -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
@@ -556,10 +556,6 @@ CMAKE_ARGS=(
     -DCPACK_PACKAGE_NAME="amdrocm${ROCM_MAJOR}-rvs"
     -DCMAKE_INSTALL_PREFIX="/opt/rocm/extras-${ROCM_MAJOR}"
     -DCPACK_PACKAGING_INSTALL_PREFIX="/opt/rocm/extras-${ROCM_MAJOR}"
-    -DCMAKE_SKIP_RPATH=FALSE
-    -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=FALSE
-    -DCMAKE_INSTALL_RPATH="\$ORIGIN:\$ORIGIN/../lib:\$ORIGIN/../lib/rvs:/opt/rocm/extras-${ROCM_MAJOR}/lib"
-    -DRPATH_MODE=OFF
     -DCMAKE_VERBOSE_MAKEFILE=1
     -DFETCH_ROCMPATH_FROM_ROCMCORE=ON
 )

--- a/docs/INSTALL_TGZ.md
+++ b/docs/INSTALL_TGZ.md
@@ -1,0 +1,90 @@
+# Installing RVS from the Linux TGZ (`.tar.gz`) archive
+
+This page describes how to **install and run** the ROCm Validation Suite (RVS) when you have the **relocatable tar.gz** produced by the project’s packaging (e.g. `amdrocm7-rvs-1.3.15-r0711.20260423-Linux.tar.gz`).
+
+- **Build pipeline, file naming, and S3 download paths** are documented in [README_BUILD_PACKAGES (GitHub workflow)](../.github/workflows/README_BUILD_PACKAGES.md#any-linux-distribution-tgz---relocatable).
+- The **same install steps** are mirrored here so the main [README](../README.md) can link to a single, copy-paste-friendly user-facing guide.
+
+---
+
+## Pre-install: ROCm
+
+Before you install the RVS TGZ, **ROCm must be installed, configured, and on your `PATH` / `LD_LIBRARY_PATH` as in AMD’s documentation** so HIP, HSA, and other ROCm libraries are discoverable. Follow the current Linux install guide in **rocm docs**:
+
+- **ROCm documentation (start here)**: <https://rocm.docs.amd.com/>
+- **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/en/latest/deploy/linux/index.html>
+
+**Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm/LLVM libraries. The TGZ only ships RVS; it does not replace a full ROCm stack.
+
+---
+
+## Install RVS run-time dependencies (on the target system)
+
+The archive is built against ROCm, but the host still needs a few system libraries. Install at least **PCI (libpci)** and **LLVM OpenMP** (**`libomp.so`**).
+
+| Family | PCI | LLVM OpenMP (`libomp.so`) |
+|--------|-----|----------------------------|
+| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0`) | **`libomp5`** on many releases (runtime SONAME may vary — use `apt search '^libomp'`). |
+| **RHEL / Rocky / Alma 8+** | `pciutils-libs` | **`libomp`** (LLVM OpenMP for Clang, **AppStream**). |
+| **openSUSE / SUSE** | `libpci3`, `pciutils` as needed | **Versioned LLVM packages**, e.g. **`libomp18`**, **`libomp17`** on Tumbleweed — names track the LLVM stack. Use **`zypper search -s libomp`** and install the **runtime** package (not only `-devel`) that matches your distro. |
+
+Examples (adjust names to your release):
+
+```bash
+# Ubuntu / Debian — LLVM OpenMP runtime
+sudo apt update
+sudo apt install -y libpci3 libomp5
+
+# RHEL / Rocky / Alma 8+ — libomp is the standard LLVM OpenMP RPM (AppStream)
+sudo dnf install -y pciutils-libs libomp
+
+# openSUSE Tumbleweed (example; Leap/SLE may use different version suffixes)
+sudo zypper install libpci3 libomp18
+# zypper search -s libomp    # list alternatives
+```
+
+**Note:** If **`libomp.so`** is still missing, it is **usually** provided with **ROCm** under **`$ROCM_PATH/lib/llvm/lib`** — the environment block below adds that path first.
+
+---
+
+## Extract the TGZ
+
+```bash
+# Example for ROCm major 7: match the extras path to your layout and the tarball name.
+sudo mkdir -p /opt/rocm/extras-7
+sudo tar -xzf amdrocm7-rvs-*.tar.gz -C /opt/rocm/extras-7
+```
+
+---
+
+## Post-install: `PATH` and `LD_LIBRARY_PATH`
+
+Point the shell at the extracted RVS prefix and the ROCm you installed (replace paths with your real `ROCM_PATH` and extras major version). **Copy and paste the block as one unit:**
+
+```bash
+export ROCM_PATH=/opt/rocm              # or your real ROCm root, per rocm docs
+export PATH=/opt/rocm/extras-7/bin:$ROCM_PATH/bin:$PATH
+export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:\
+$ROCM_PATH/lib:\
+$ROCM_PATH/lib/llvm/lib:\
+$LD_LIBRARY_PATH
+```
+
+**`libomp` (LLVM OpenMP):** `$ROCM_PATH/lib/llvm/lib` is already in the `export` block above — **`libomp.so` is often there** (ROCm’s LLVM). If your layout differs, run `find $ROCM_PATH -name 'libomp.so' 2>/dev/null` and add that directory to `LD_LIBRARY_PATH`, or install the host **`libomp`** packages from the table above.
+
+---
+
+## Run RVS
+
+```bash
+rvs --help
+```
+
+(You can also add `/opt/rocm/extras-7/bin` to your user profile or system `PATH` so `rvs` is on the default path in new shells.)
+
+---
+
+## See also
+
+- [CI / packaging: README_BUILD_PACKAGES.md](../.github/workflows/README_BUILD_PACKAGES.md) — building packages, S3, DEB/RPM, and the full **Installing generated packages** section
+- [User guide: module configuration and examples](ug1main.md)

--- a/docs/INSTALL_TGZ.md
+++ b/docs/INSTALL_TGZ.md
@@ -9,41 +9,37 @@ This page describes how to **install and run** the ROCm Validation Suite (RVS) w
 
 ## Pre-install: ROCm
 
-Before you install the RVS TGZ, **ROCm must be installed, configured, and on your `PATH` / `LD_LIBRARY_PATH` as in AMD’s documentation** so HIP, HSA, and other ROCm libraries are discoverable. Follow the current Linux install guide in **rocm docs**:
+Before you install the RVS TGZ, **ROCm must be installed, configured, and on your `PATH` / `LD_LIBRARY_PATH` as in AMD’s documentation** so HIP, HSA, LLVM, and other ROCm libraries are discoverable. Install a stack that includes **ROCm’s LLVM** (for example the **`rocm-llvm`** package, or an equivalent meta-package from your ROCm repo). Follow **rocm docs**:
 
 - **ROCm documentation (start here)**: <https://rocm.docs.amd.com/>
 - **Linux install / deployment (paths, env, post-install)**: <https://rocm.docs.amd.com/en/latest/deploy/linux/index.html>
 
-**Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm/LLVM libraries. The TGZ only ships RVS; it does not replace a full ROCm stack.
+**Assumptions (TGZ use):** ROCm is set up on the machine, `ROCM_PATH` (or your install prefix) is correct, and the runtime can load ROCm libraries. The RVS build records **`RPATH`** entries with **`$ORIGIN`-relative** paths for the extras install, plus **`/opt/rocm/lib`**, **`/opt/rocm/lib/llvm/lib`** (older ROCm layouts), **`/opt/rocm/core-<ROCmMajor>/lib`**, and **`/opt/rocm/core-<ROCmMajor>/lib/llvm/lib`** for the ROCm stack and LLVM (including OpenMP from ROCm’s LLVM). The TGZ only ships RVS; it does not replace a full ROCm stack.
 
 ---
 
 ## Install RVS run-time dependencies (on the target system)
 
-The archive is built against ROCm, but the host still needs a few system libraries. Install at least **PCI (libpci)** and **LLVM OpenMP** (**`libomp.so`**).
+Install **PCI** access for GPU enumeration where your distro does not already provide it:
 
-| Family | PCI | LLVM OpenMP (`libomp.so`) |
-|--------|-----|----------------------------|
-| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0`) | **`libomp5`** on many releases (runtime SONAME may vary — use `apt search '^libomp'`). |
-| **RHEL / Rocky / Alma 8+** | `pciutils-libs` | **`libomp`** (LLVM OpenMP for Clang, **AppStream**). |
-| **openSUSE / SUSE** | `libpci3`, `pciutils` as needed | **Versioned LLVM packages**, e.g. **`libomp18`**, **`libomp17`** on Tumbleweed — names track the LLVM stack. Use **`zypper search -s libomp`** and install the **runtime** package (not only `-devel`) that matches your distro. |
-
-Examples (adjust names to your release):
+| Family | Typical package |
+|--------|-----------------|
+| **Debian / Ubuntu** | `libpci3` (or `libpci-3-0-0` on some releases) |
+| **RHEL / Rocky / Alma** | `pciutils-libs` |
+| **SUSE / openSUSE** | `libpci3` / `pciutils` as appropriate for the release |
 
 ```bash
-# Ubuntu / Debian — LLVM OpenMP runtime
-sudo apt update
-sudo apt install -y libpci3 libomp5
+# Ubuntu / Debian
+sudo apt update && sudo apt install -y libpci3
 
-# RHEL / Rocky / Alma 8+ — libomp is the standard LLVM OpenMP RPM (AppStream)
-sudo dnf install -y pciutils-libs libomp
+# RHEL / Rocky / Alma 8+
+sudo dnf install -y pciutils-libs
 
-# openSUSE Tumbleweed (example; Leap/SLE may use different version suffixes)
-sudo zypper install libpci3 libomp18
-# zypper search -s libomp    # list alternatives
+# openSUSE / SUSE
+sudo zypper install libpci3
 ```
 
-**Note:** If **`libomp.so`** is still missing, it is **usually** provided with **ROCm** under **`$ROCM_PATH/lib/llvm/lib`** — the environment block below adds that path first.
+The **DEB/RPM** packages from this project declare a dependency on **`rocm-llvm`** (ROCm LLVM, including the OpenMP runtime used at link time). Prefer installing RVS via those packages when possible so dependencies resolve automatically.
 
 ---
 
@@ -59,18 +55,15 @@ sudo tar -xzf amdrocm7-rvs-*.tar.gz -C /opt/rocm/extras-7
 
 ## Post-install: `PATH` and `LD_LIBRARY_PATH`
 
-Point the shell at the extracted RVS prefix and the ROCm you installed (replace paths with your real `ROCM_PATH` and extras major version). **Copy and paste the block as one unit:**
+Point the shell at the extracted RVS prefix and ROCm (adjust paths to match your install):
 
 ```bash
 export ROCM_PATH=/opt/rocm              # or your real ROCm root, per rocm docs
 export PATH=/opt/rocm/extras-7/bin:$ROCM_PATH/bin:$PATH
-export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:\
-$ROCM_PATH/lib:\
-$ROCM_PATH/lib/llvm/lib:\
-$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:$ROCM_PATH/lib:$ROCM_PATH/lib/llvm/lib:${LD_LIBRARY_PATH}
 ```
 
-**`libomp` (LLVM OpenMP):** `$ROCM_PATH/lib/llvm/lib` is already in the `export` block above — **`libomp.so` is often there** (ROCm’s LLVM). If your layout differs, run `find $ROCM_PATH -name 'libomp.so' 2>/dev/null` and add that directory to `LD_LIBRARY_PATH`, or install the host **`libomp`** packages from the table above.
+**`rvs`** embeds **`RPATH`** for the ROCm stack and LLVM (see **Pre-install: ROCm**), including **`/opt/rocm/lib/llvm/lib`** where applicable, so it usually does not need **`LD_LIBRARY_PATH`** for them. The export still adds **`$ROCM_PATH/lib/llvm/lib`** so your environment matches a typical ROCm tree and works for other tools; if LLVM on your system is only under **`$ROCM_PATH/core-<major>/lib/llvm/lib`**, include that path instead or as well.
 
 ---
 


### PR DESCRIPTION
Since TGZ based install cannot manage dependencies and setup env, user need to know what are the pre-install and post install checklist that need to be done to make rvs functional.

RVS need libomp from llvm/lib provided in ROCm to work. Hence add RPATH/RUNPATH to ROCm_path/lib and ROCm_path/lib/llvm/lib. Anytime ROCm is installed in a non-standard location using TGZ user shall be instructed to set LD_LIBRARY_PATH with appropriate path

Also cleaned up build RPATH if built from github and keep it only in the case of local build(using CMAKE_SKIP_BUILD_RPATH).

