### PR TITLE
update repo meta data and repo file instruction

### DIFF
--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -197,17 +197,20 @@ s3://<bucket>/nightly/rvs/
 **Using the S3 repo with apt (Ubuntu/Debian):**
 
 ```bash
-# Add the nightly repo (replace <bucket> with the actual S3 bucket name)
-echo "deb [trusted=yes] https://<bucket>.s3.amazonaws.com/nightly/rvs/deb/ ./" \
+# Add the nightly repo (replace <bucket> with the actual S3 bucket name).
+# Use "/" as the suite field for this flat repo layout.
+echo "deb [trusted=yes] https://<bucket>.s3.amazonaws.com/nightly/rvs/deb /" \
   | sudo tee /etc/apt/sources.list.d/rvs-nightly.list
 
 # Or the release repo
-echo "deb [trusted=yes] https://<bucket>.s3.amazonaws.com/release/rvs/deb/ ./" \
+echo "deb [trusted=yes] https://<bucket>.s3.amazonaws.com/release/rvs/deb /" \
   | sudo tee /etc/apt/sources.list.d/rvs-release.list
 
 sudo apt update
 sudo apt install amdrocm7-rvs  # Replace 7 with your ROCm major version
 ```
+
+After `apt update`, **`apt list`** should show **`rvs-nightly`** or **`rvs-release`** (matching the bucket: `nightly/rvs/deb` vs `release/rvs/deb`) in the suite/codename column, because CI sets `Suite`, `Label`, and `Codename` in the flat `Release` file via `apt-ftparchive` options. If you still see **`unknown`**, run `apt update` again after a fresh metadata upload, or check that your `Release` on the server includes those fields. **`apt install amdrocm7-rvs`** still resolves versions from `Packages` either way.
 
 **Using the S3 repo with yum/dnf (CentOS/RHEL/Rocky):**
 

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -183,8 +183,10 @@ jobs:
           BASE="rvs"
           if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
             DEB_PREFIX="release/${BASE}/deb"
+            APT_SUITE="rvs-release"
           else
             DEB_PREFIX="nightly/${BASE}/deb"
+            APT_SUITE="rvs-nightly"
           fi
 
           STAGING=$(mktemp -d)
@@ -198,8 +200,16 @@ jobs:
 
           cd "$STAGING"
           dpkg-scanpackages --multiversion . /dev/null > Packages
+          # dpkg-scanpackages emits "Filename: ./foo.deb". APT resolves that under the repo URL and may
+          # request .../deb/./foo.deb — S3/CloudFront keys are literal, so that path 404s. Strip "./".
+          sed -i 's#^Filename: \./#Filename: #g' Packages
           gzip -k -f Packages
-          apt-ftparchive release . > Release
+          apt-ftparchive \
+            -o APT::FTPArchive::Release::Origin="ROCm Validation Suite" \
+            -o APT::FTPArchive::Release::Label="${APT_SUITE}" \
+            -o APT::FTPArchive::Release::Suite="${APT_SUITE}" \
+            -o APT::FTPArchive::Release::Codename="${APT_SUITE}" \
+            release . > Release
 
           aws s3 sync "$STAGING/" "s3://${BUCKET}/${DEB_PREFIX}/" --no-progress
 


### PR DESCRIPTION
## Motivation

Debian repo setup was failing with the existing method. This fix is to make sure debian install works fine.
Meta data pull failed initially and the once that was fixed with setup instruction change meta data is failing since all the files have "./" to refer the name.

This fix is to ensure metadata is updated without "./".
To fix the existing repodata in nightly, this change need to be merged as only merged changes/build can touch the repo data.

Also added a label for nightly and release repo.

## Test Plan

Once merged and image generated test debian setup and install is working fine.

## Test Result

Listing... Done
amdrocm7-rvs/rvs-nightly,now 1.4.18-r0711.20260430 amd64 [installed]
N: There are 14 additional versions. Please use the '-a' switch to see them.

