### PR TITLE
static link yaml-cpp for ubuntu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,9 +411,14 @@ message (STATUS "CPACK_GENERATOR ${CPACK_GENERATOR}" )
 ################################################################################
 # check yaml-cpp available at configure time
 # First try to find static yaml-cpp library
-find_library(YAML_CPP_STATIC_LIB 
+find_library(YAML_CPP_STATIC_LIB
   NAMES libyaml-cpp.a yaml-cpp.a
-  PATHS /usr/lib64 /usr/lib /usr/local/lib64 /usr/local/lib
+  PATHS
+    /usr/lib/x86_64-linux-gnu
+    /usr/lib64
+    /usr/lib
+    /usr/local/lib64
+    /usr/local/lib
   NO_DEFAULT_PATH # avoid searches in cmake_install_prefix etc
   DOC "Path to yaml-cpp static library"
 )


### PR DESCRIPTION
## Motivation

Ubuntu 22.04 install libyaml-cpp.a in /usr/lib/x86_64-linux-gnu/. Add this path so that both OS link libyaml-cpp as static.

/usr/lib/x86_64-linux-gnu/libyaml-cpp.a

## Technical Details

Having yaml-cpp linked static, this should help use the same .deb file on higher version of Ubuntu OS as well.
Ubuntu 22.04 has 0.7 and 24.04 has 0.8.

## Test Plan

Install and test RVS on Ubuntu 24.04 docker
 
## Test Result

2026-04-30T16:55:52.4330175Z -- CPACK_GENERATOR DEB
2026-04-30T16:55:52.4356284Z -- yaml-cpp shared library found: yaml-cpp
2026-04-30T16:55:52.4356821Z -- Using yaml-cpp SHARED library: yaml-cpp
2026-04-30T16:55:52.4357514Z -- Package dependencies: yaml-cpp dynamically linked, runtime dependency included

With change: 
 0x0000000000000001 (NEEDED)             Shared library: [librvslib.so.0.0.0711]
 0x0000000000000001 (NEEDED)             Shared library: [librocblas.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libamd_smi.so.26]
 0x0000000000000001 (NEEDED)             Shared library: [libhsa-runtime64.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [librocm-core.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpci.so.3]
 0x0000000000000001 (NEEDED)             Shared library: [libhiprand.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libhipblaslt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libamdhip64.so.7]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libomp.so]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

Without change: 
 0x0000000000000001 (NEEDED)             Shared library: [librvslib.so.0.0.0711]
 0x0000000000000001 (NEEDED)             Shared library: [librocblas.so.5]
 0x0000000000000001 (NEEDED)             Shared library: [libamd_smi.so.26]
 0x0000000000000001 (NEEDED)             Shared library: [libhsa-runtime64.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [librocm-core.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpci.so.3]
 **0x0000000000000001 (NEEDED)             Shared library: [libyaml-cpp.so.0.7]**
 0x0000000000000001 (NEEDED)             Shared library: [libhiprand.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libhipblaslt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libamdhip64.so.7]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libomp.so]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

