### PR TITLE
update workflow for ROCm download

### DIFF
--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -16,16 +16,32 @@ All packages are built with relocatable RPATH settings, meaning they can be inst
 The workflow runs automatically on:
 - Push to `master`, `main`, or `release/**` branches
 - Pull requests to `master` or `main` branches
-- **Scheduled**: Daily at **5:00 AM PST** (13:00 UTC); uses **latest ROCm version** (auto-fetched from TheRock)
-- Manual trigger via GitHub Actions UI (workflow_dispatch)
+- **Scheduled**: Daily at **5:00 AM PST** (13:00 UTC); **latest ROCm nightly** from [ROCm SDK nightly tarballs](https://rocm.nightlies.amd.com/tarball-multi-arch/) (or repo variable overrides).
+- **Pull requests** and **pushes** to `master`, `main`, or `release/**` (including merges): **latest ROCm release** (**X.Y.Z**) from [repo.amd.com ROCm tarballs](https://repo.amd.com/rocm/tarball/).
+- **Manual** (`workflow_dispatch`): if **`ROCM_VERSION`** is pinned (**workflow input** and/or **`vars.ROCM_VERSION`**), the tarball is chosen by **version format** (nightly `x.y.za…` vs release `X.Y.Z`). If no version is pinned, the job uses **latest nightly** (same as schedule).
+
+### ROCm SDK: nightly vs release in CI
+
+The workflow sets `ROCM_SDK_CHANNEL` and SDK URLs before calling `build_packages_local.sh`:
+
+| Trigger | SDK source |
+|---------|------------|
+| **`schedule`** | **Nightly** — latest nightly tarball from the nightly listing |
+| **`pull_request`** (to `master` / `main`) | **Release** — latest **X.Y.Z** from the release listing |
+| **`push`** to `master`, `main`, or `release/**` | **Release** — same (covers merge-after-PR) |
+| **`push`** to other branches | **Nightly** |
+| **`workflow_dispatch`** | **Format-based** when `rocm_version` input or `vars.ROCM_VERSION` is set; otherwise **latest nightly** |
+
+Local builds (no CI): default is **latest nightly** if `ROCM_VERSION` is unset; if set, tarball location follows the same **format** rules as in `build_packages_local.sh`.
 
 ### Manual Trigger Parameters
 
 When manually triggering the workflow, you can specify:
 
-1. **ROCm Version** (e.g., `7.11.0a20260121`)
-   - Default: empty (auto-fetches latest from TheRock)
-   - Or specify an explicit version string
+1. **ROCm Version**
+   - Empty — **latest nightly** (unless `vars.ROCM_VERSION` is set in the repo, which pins a version and triggers format-based selection).
+   - **`X.Y.Z`** — release tarball at [repo.amd.com](https://repo.amd.com/rocm/tarball/).
+   - **`x.y.za…`** — nightly tarball at [nightlies](https://rocm.nightlies.amd.com/tarball-multi-arch/).
    
 2. **GPU Family Target**:
    - `gfx94X-dcgpu` - MI300A/MI300X
@@ -284,7 +300,14 @@ sudo BUILD_TYPE=Debug ./build_packages_local.sh
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ROCM_VERSION` | Auto-fetched (fallback: `7.11.0a20260121`) | ROCm SDK version from TheRock. If not set, script fetches latest version automatically. |
+| `ROCM_VERSION` | _(unset)_ | If set, selects tarball by **format** (see below). If unset locally: **latest nightly**. If unset in CI: channel selects latest **nightly** vs **release X.Y.Z**. |
+| `ROCM_SDK_RELEASE_URL` | `https://repo.amd.com/rocm/tarball/` | HTML listing for **release** tarballs (`therock-dist-linux-<GPU_FAMILY>-X.Y.Z.tar.gz`). Used when `ROCM_SDK_CHANNEL=release` or `auto` with this URL set. |
+| `ROCM_SDK_RELEASE_BASE_URL` | `https://repo.amd.com/rocm/tarball` | Directory URL for downloading **X.Y.Z** tarballs; overridden when version string is nightly-shaped. |
+| `ROCM_SDK_BASE_URL` | See script | Effective tarball base after channel + version-shape resolution. |
+| `ROCM_SDK_INDEX_URL` | `https://rocm.nightlies.amd.com/tarball-multi-arch/` | **Nightly** listing for latest nightly SDK discovery. |
+| `ROCM_SDK_NIGHTLY_BASE_URL` | `https://rocm.nightlies.amd.com/tarball-multi-arch` | Tarball base for **nightly** builds (`x.y.za…` versions). |
+| `ROCM_SDK_NIGHTLY_INDEX_URL` | _(same as index default)_ | Optional override for nightly listing URL. |
+| `ROCM_SDK_CHANNEL` | `auto` locally | **`nightly`** / **`release`** / **`auto`**. CI sets channel per trigger (see table above); manual with a pin uses **`auto`** so tarball follows version format. |
 | `GPU_FAMILY` | `gfx110X-all` | Target GPU architecture |
 | `BUILD_TYPE` | `Release` | CMake build type (Release/Debug) |
 | `ROCM_LIBPATCH_VERSION` | Auto-extracted from `ROCM_VERSION` | Major.minor in xxyy format with zero padding (e.g., `7.11` → `0711`, `8.0` → `0800`) - used for RVS version tagging |

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       rocm_version:
-        description: 'ROCm version (e.g., 7.11.0a20260121)'
+        description: 'Optional pin — empty uses latest nightly (unless vars.ROCM_VERSION set). Release X.Y.Z vs nightly x.y.za… selects tarball host by format.'
         required: false
         default: ''
       gpu_family:
@@ -36,7 +36,9 @@ permissions:
   id-token: write
 
 env:
-  ROCM_VERSION: ${{ vars.ROCM_VERSION || '7.11.0a20260121' }}
+  # Leave unset unless you pin a version via repo variable or workflow_dispatch input.
+  # With vars.ROCM_SDK_RELEASE_URL set, the script picks latest X.Y.Z from that listing for GPU_FAMILY.
+  ROCM_VERSION: ${{ vars.ROCM_VERSION }}
   GPU_FAMILY: ${{ vars.GPU_FAMILY || 'gfx110X-all' }}
   BUILD_TYPE: Release
   # Optional Step 6 in build_packages_local.sh: set repo Actions variable
@@ -79,16 +81,88 @@ jobs:
             echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
           fi
 
+      # Schedule → latest ROCm *nightly*. PR + merge (push to main/master/release/*) → latest ROCm *release*.
+      # Manual: if a version is pinned (workflow input or vars.ROCM_VERSION), tarball follows *format* (auto).
+      - name: Configure ROCm SDK channel (nightly vs release)
+        run: |
+          NIGHTLY_BASE='${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}'
+          NIGHTLY_IDX='${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}'
+          [ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
+          [ -z "$NIGHTLY_IDX" ] && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
+
+          REL_URL='${{ vars.ROCM_SDK_RELEASE_URL }}'
+          [ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
+          REL_BASE='${{ vars.ROCM_SDK_RELEASE_BASE_URL }}'
+          [ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
+
+          release_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=release"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_BASE_URL=$REL_BASE"
+              echo "ROCM_SDK_INDEX_URL="
+            } >> "$GITHUB_ENV"
+          }
+
+          nightly_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=nightly"
+              echo "ROCM_SDK_RELEASE_URL="
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+            } >> "$GITHUB_ENV"
+          }
+
+          # Manual run with a pin: resolve tarball location by version format (nightly x.y.za… vs release X.Y.Z)
+          format_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=auto"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+            } >> "$GITHUB_ENV"
+          }
+
+          EVENT='${{ github.event_name }}'
+          REF='${{ github.ref }}'
+          IN_VER='${{ github.event.inputs.rocm_version }}'
+          VAR_VER='${{ vars.ROCM_VERSION }}'
+
+          if [ "$EVENT" = "schedule" ]; then
+            nightly_build
+            echo "ROCm SDK channel: nightly (scheduled — latest nightly)"
+          elif [ "$EVENT" = "pull_request" ]; then
+            release_build
+            echo "ROCm SDK channel: release (pull request — latest X.Y.Z)"
+          elif [ "$EVENT" = "push" ]; then
+            if [ "$REF" = "refs/heads/master" ] || [ "$REF" = "refs/heads/main" ] || [[ "$REF" == refs/heads/release/* ]]; then
+              release_build
+              echo "ROCm SDK channel: release (push to main or release/* — includes merge)"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (push to feature branch)"
+            fi
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
+              format_build
+              echo "ROCm SDK: manual — tarball base chosen by version format (input or vars.ROCM_VERSION)"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (manual, no version pin)"
+            fi
+          else
+            nightly_build
+            echo "ROCm SDK channel: nightly (fallback)"
+          fi
+
       - name: Build and Package RVS
         run: |
           chmod +x build_packages_local.sh
-           # Run build script with sudo (Ubuntu runner needs sudo for apt-get)
-          sudo -E ROCM_VERSION=${{ env.ROCM_VERSION }} \
-          GPU_FAMILY=${{ env.GPU_FAMILY }} \
-          BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          ROCM_SDK_BASE_URL=${{ vars.ROCM_SDK_BASE_URL }} \
-          ROCM_SDK_INDEX_URL=${{ vars.ROCM_SDK_INDEX_URL }} \
-          ./build_packages_local.sh
+          # ROCM_SDK_* come from "Configure ROCm SDK channel" via GITHUB_ENV; sudo -E preserves them.
+          sudo -E ./build_packages_local.sh
 
       - name: Fix file ownership
         if: always()
@@ -251,15 +325,84 @@ jobs:
             echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
           fi
 
+      # Schedule → nightly latest. PR + merge → release latest. Manual → format when version pinned.
+      - name: Configure ROCm SDK channel (nightly vs release)
+        run: |
+          NIGHTLY_BASE='${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}'
+          NIGHTLY_IDX='${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}'
+          [ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
+          [ -z "$NIGHTLY_IDX" ] && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
+
+          REL_URL='${{ vars.ROCM_SDK_RELEASE_URL }}'
+          [ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
+          REL_BASE='${{ vars.ROCM_SDK_RELEASE_BASE_URL }}'
+          [ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
+
+          release_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=release"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_BASE_URL=$REL_BASE"
+              echo "ROCM_SDK_INDEX_URL="
+            } >> "$GITHUB_ENV"
+          }
+
+          nightly_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=nightly"
+              echo "ROCM_SDK_RELEASE_URL="
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+            } >> "$GITHUB_ENV"
+          }
+
+          format_build() {
+            {
+              echo "ROCM_SDK_CHANNEL=auto"
+              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
+              echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
+              echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+            } >> "$GITHUB_ENV"
+          }
+
+          EVENT='${{ github.event_name }}'
+          REF='${{ github.ref }}'
+          IN_VER='${{ github.event.inputs.rocm_version }}'
+          VAR_VER='${{ vars.ROCM_VERSION }}'
+
+          if [ "$EVENT" = "schedule" ]; then
+            nightly_build
+            echo "ROCm SDK channel: nightly (scheduled)"
+          elif [ "$EVENT" = "pull_request" ]; then
+            release_build
+            echo "ROCm SDK channel: release (pull request)"
+          elif [ "$EVENT" = "push" ]; then
+            if [ "$REF" = "refs/heads/master" ] || [ "$REF" = "refs/heads/main" ] || [[ "$REF" == refs/heads/release/* ]]; then
+              release_build
+              echo "ROCm SDK channel: release (push to main or release/*)"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (feature branch push)"
+            fi
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
+              format_build
+              echo "ROCm SDK: manual — format-based tarball"
+            else
+              nightly_build
+              echo "ROCm SDK channel: nightly (manual, no version)"
+            fi
+          else
+            nightly_build
+            echo "ROCm SDK channel: nightly (fallback)"
+          fi
+
       - name: Build and Package RVS
         run: |
           chmod +x build_packages_local.sh
-          
-          ROCM_VERSION=${{ env.ROCM_VERSION }} \
-          GPU_FAMILY=${{ env.GPU_FAMILY }} \
-          BUILD_TYPE=${{ env.BUILD_TYPE }} \
-          ROCM_SDK_BASE_URL=${{ vars.ROCM_SDK_BASE_URL }} \
-          ROCM_SDK_INDEX_URL=${{ vars.ROCM_SDK_INDEX_URL }} \
           ./build_packages_local.sh
 
       - name: Verify RPM Package

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -47,7 +47,8 @@ elif [ "$ROCM_SDK_CHANNEL" = "release" ]; then
         if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
             ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
         else
-            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/*}"
+            # Same directory as listing: strip trailing / only (not %/* — that drops /tarball when URL has no trailing slash).
+            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/}"
         fi
     fi
     ROCM_SDK_INDEX_URL="${ROCM_SDK_INDEX_URL:-}"
@@ -58,7 +59,8 @@ else
             if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
                 ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
             else
-                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/*}"
+                # Listing URL and tarball base share the same path; normalize trailing slash only.
+                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/}"
             fi
         fi
     else

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -13,13 +13,59 @@ BUILD_DIR="./build"
 ROCM_INSTALL_DIR="$HOME/rocm-sdk"
 
 # SDK Source Configuration
-# Default: TheRock public S3 nightly bucket (works from any network).
-# Override via environment variables or GitHub Actions repository variables (vars.*).
+# Defaults point at AMD-hosted listings (override via env or GitHub vars).
+# - Nightly index: https://rocm.nightlies.amd.com/tarball-multi-arch/
+# - Release listing: https://repo.amd.com/rocm/tarball/
 #
-# If your SDK server has no index page for auto-detection, set ROCM_SDK_INDEX_URL=""
-# and provide ROCM_VERSION explicitly.
-ROCM_SDK_BASE_URL="${ROCM_SDK_BASE_URL:-https://therock-nightly-tarball.s3.us-east-2.amazonaws.com}"
-ROCM_SDK_INDEX_URL="${ROCM_SDK_INDEX_URL:-https://therock-nightly-tarball.s3.amazonaws.com/index.html}"
+# Local builds: if ROCM_VERSION is unset (channel auto, no release listing env), latest *nightly* is fetched.
+# If ROCM_VERSION is set, tarball base follows format:
+# - Nightly: x.y.za<date> (e.g. 7.11.0a20260121) → nightly base URL
+# - Release: X.Y.Z (e.g. 7.11.0) → release base URL
+#
+# ROCM_SDK_CHANNEL: nightly | release | auto (default auto).
+# - nightly: latest SDK from nightly listing (ROCM_SDK_INDEX_URL).
+# - release: latest X.Y.Z from release listing (ROCM_SDK_RELEASE_URL).
+# - auto: release listing URL set → release discovery; else nightly index.
+#
+# Optional: ROCM_SDK_NIGHTLY_BASE_URL, ROCM_SDK_NIGHTLY_INDEX_URL, ROCM_SDK_RELEASE_URL (listing),
+# ROCM_SDK_RELEASE_BASE_URL (tarball directory for X.Y.Z downloads).
+_ROCM_NIGHTLY_INDEX_DEFAULT="https://rocm.nightlies.amd.com/tarball-multi-arch/"
+_ROCM_NIGHTLY_BASE_DEFAULT="https://rocm.nightlies.amd.com/tarball-multi-arch"
+_ROCM_RELEASE_LIST_DEFAULT="https://repo.amd.com/rocm/tarball/"
+_ROCM_RELEASE_BASE_DEFAULT="https://repo.amd.com/rocm/tarball"
+
+ROCM_SDK_CHANNEL="${ROCM_SDK_CHANNEL:-auto}"
+ROCM_SDK_RELEASE_URL="${ROCM_SDK_RELEASE_URL:-}"
+
+if [ "$ROCM_SDK_CHANNEL" = "nightly" ]; then
+    ROCM_SDK_RELEASE_URL=""
+    ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_NIGHTLY_INDEX_URL:-${ROCM_SDK_INDEX_URL:-$_ROCM_NIGHTLY_INDEX_DEFAULT}}"
+elif [ "$ROCM_SDK_CHANNEL" = "release" ]; then
+    ROCM_SDK_RELEASE_URL="${ROCM_SDK_RELEASE_URL:-$_ROCM_RELEASE_LIST_DEFAULT}"
+    if [ -z "${ROCM_SDK_BASE_URL:-}" ]; then
+        if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
+            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
+        else
+            ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/*}"
+        fi
+    fi
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_INDEX_URL:-}"
+else
+    # auto (local: no release URL → nightly latest; CI sets channel explicitly)
+    if [ -n "${ROCM_SDK_RELEASE_URL}" ]; then
+        if [ -z "${ROCM_SDK_BASE_URL:-}" ]; then
+            if [ -n "${ROCM_SDK_RELEASE_BASE_URL:-}" ]; then
+                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL}"
+            else
+                ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_URL%/*}"
+            fi
+        fi
+    else
+        ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+    fi
+    ROCM_SDK_INDEX_URL="${ROCM_SDK_NIGHTLY_INDEX_URL:-${ROCM_SDK_INDEX_URL:-$_ROCM_NIGHTLY_INDEX_DEFAULT}}"
+fi
 
 # Post-build upload configuration
 # Set UPLOAD_TARGET to enable automatic upload of built packages after the build.
@@ -69,6 +115,27 @@ print_error() {
     echo -e "${RED}[ERROR]${NC} $1" >&2
 }
 
+# Join base URL and filename without duplicate slashes
+join_base_and_file() {
+    local base="$1"
+    local path="$2"
+    base="${base%/}"
+    printf '%s/%s' "$base" "$path"
+}
+
+# After ROCM_VERSION is known: pick tarball host directory from version shape (overrides channel defaults).
+# Nightly: x.y.za<digits>  Release: X.Y.Z (three-part semver only)
+apply_sdk_tarball_base_for_version() {
+    local v="$1"
+    if echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+a[0-9]+'; then
+        ROCM_SDK_BASE_URL="${ROCM_SDK_NIGHTLY_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_NIGHTLY_BASE_DEFAULT}}"
+        print_info "Version matches ROCm nightly format (x.y.za…) → tarball base: $ROCM_SDK_BASE_URL"
+    elif echo "$v" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        ROCM_SDK_BASE_URL="${ROCM_SDK_RELEASE_BASE_URL:-${ROCM_SDK_BASE_URL:-$_ROCM_RELEASE_BASE_DEFAULT}}"
+        print_info "Version matches ROCm release format (X.Y.Z) → tarball base: $ROCM_SDK_BASE_URL"
+    fi
+}
+
 # Function to fetch latest ROCm version for specified GPU family
 # Sets the global ROCM_VERSION variable directly
 fetch_latest_rocm_version() {
@@ -84,13 +151,35 @@ fetch_latest_rocm_version() {
         sort -V | tail -1)
     
     if [ -z "$latest_version" ]; then
-        print_error "Could not fetch latest ROCm version for $gpu_family"
-        print_info "Falling back to default version: 7.11.0a20260121"
-        ROCM_VERSION="7.11.0a20260121"
+        print_error "Could not fetch latest ROCm nightly version for $gpu_family from $ROCM_SDK_INDEX_URL"
         return 1
     fi
-    
+
     print_success "Found latest ROCm version: $latest_version"
+    ROCM_VERSION="$latest_version"
+    return 0
+}
+
+# Fetch latest ROCm *release* tarball version (semantic X.Y.Z only; excludes nightly builds like 7.11.0a20260121).
+# Parses ROCM_SDK_RELEASE_URL (HTML listing / index). Sets ROCM_VERSION.
+fetch_latest_rocm_release_version() {
+    local gpu_family="$1"
+    local list_url="${ROCM_SDK_RELEASE_URL:-$_ROCM_RELEASE_LIST_DEFAULT}"
+
+    print_info "Fetching latest ROCm release version (X.Y.Z) for $gpu_family..."
+    print_info "Release listing URL: $list_url"
+
+    local latest_version
+    latest_version=$(wget -qO- "$list_url" 2>/dev/null | \
+        grep -oP "therock-dist-linux-${gpu_family}-\K[0-9]+\.[0-9]+\.[0-9]+(?=\.tar\.gz)" | \
+        sort -V | uniq | tail -1)
+
+    if [ -z "$latest_version" ]; then
+        print_error "No therock-dist-linux-${gpu_family}-X.Y.Z.tar.gz found under release listing (expected forms like 7.11.0)"
+        return 1
+    fi
+
+    print_success "Found latest ROCm release version: $latest_version"
     ROCM_VERSION="$latest_version"
     return 0
 }
@@ -293,12 +382,40 @@ check_and_install_dependencies() {
 # Check and install dependencies (installs wget, etc. - required before fetch_latest_rocm_version)
 check_and_install_dependencies
 
-# Determine ROCm version: use environment variable or fetch latest (wget is now available)
+# Determine ROCm version: explicit env > channel-specific listing
 if [ -n "$ROCM_VERSION" ]; then
     print_info "Using specified ROCm version: $ROCM_VERSION"
+elif [ "$ROCM_SDK_CHANNEL" = "nightly" ]; then
+    print_info "No ROCm version specified; fetching latest from ROCm nightly index (channel=nightly)..."
+    if [ -z "$ROCM_SDK_INDEX_URL" ]; then
+        print_error "ROCM_SDK_CHANNEL=nightly requires ROCM_SDK_INDEX_URL"
+        exit 1
+    fi
+    fetch_latest_rocm_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm nightly version"
+        exit 1
+    fi
+elif [ "$ROCM_SDK_CHANNEL" = "release" ]; then
+    print_info "No ROCm version specified; fetching latest release X.Y.Z from ROCM_SDK_RELEASE_URL..."
+    if [ -z "$ROCM_SDK_RELEASE_URL" ]; then
+        print_error "ROCM_SDK_CHANNEL=release requires ROCM_SDK_RELEASE_URL when ROCM_VERSION is unset"
+        exit 1
+    fi
+    fetch_latest_rocm_release_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm release version"
+        exit 1
+    fi
+elif [ -n "$ROCM_SDK_RELEASE_URL" ]; then
+    print_info "No ROCm version specified; resolving latest release from ROCM_SDK_RELEASE_URL (channel=auto)..."
+    fetch_latest_rocm_release_version "$GPU_FAMILY"
+    if [ -z "$ROCM_VERSION" ]; then
+        print_error "Failed to determine ROCm release version"
+        exit 1
+    fi
 elif [ -n "$ROCM_SDK_INDEX_URL" ]; then
-    # Auto-detection only works when an index URL is available (e.g. S3 bucket)
-    print_info "No ROCm version specified, fetching latest from index..."
+    print_info "No ROCm version specified, fetching latest from nightly index (channel=auto)..."
     fetch_latest_rocm_version "$GPU_FAMILY"
 
     if [ -z "$ROCM_VERSION" ]; then
@@ -307,25 +424,23 @@ elif [ -n "$ROCM_SDK_INDEX_URL" ]; then
     fi
 else
     print_error "ROCM_VERSION is required"
-    print_info "The configured SDK server does not provide an index page for auto-detection."
-    print_info "Set it via environment variable, e.g.:"
+    print_info "Set ROCM_VERSION, or configure ROCM_SDK_RELEASE_URL (release X.Y.Z tarballs) or ROCM_SDK_INDEX_URL (nightly listing)."
+    print_info "Example:"
     echo ""
-    echo "  export ROCM_VERSION=\"7.11.0a20260121\""
+    echo "  export ROCM_VERSION=\"7.11.0\""
     echo "  ./build_packages_local.sh"
-    echo ""
-    print_info "Or in GitHub Actions workflow:"
-    echo ""
-    echo "  env:"
-    echo "    ROCM_VERSION: \"7.11.0a20260121\""
     echo ""
     exit 1
 fi
+
+apply_sdk_tarball_base_for_version "$ROCM_VERSION"
 
 # Print configuration
 echo "================================================================================"
 echo "  ROCm Validation Suite - Local Package Build Script"
 echo "================================================================================"
 print_info "ROCm Version: $ROCM_VERSION"
+print_info "ROCm SDK channel: ${ROCM_SDK_CHANNEL:-auto}"
 print_info "GPU Family: $GPU_FAMILY"
 print_info "Build Type: $BUILD_TYPE"
 print_info "Build Directory: $BUILD_DIR"
@@ -340,7 +455,7 @@ echo ""
 
 # Step 1: Download ROCm SDK
 print_info "Step 1: Downloading ROCm SDK tarball..."
-TARBALL_URL="${ROCM_SDK_BASE_URL}/therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz"
+TARBALL_URL=$(join_base_and_file "$ROCM_SDK_BASE_URL" "therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz")
 TARBALL_FILE="$ROCM_INSTALL_DIR/rocm-sdk.tar.gz"
 
 mkdir -p "$ROCM_INSTALL_DIR"


### PR DESCRIPTION


## Motivation

Workflow was defaulting to ROCm 7.11 from AWS S3. This location has changed. Updated workflow to pick ROCm based on job/version information.

## Technical Details

Scheduled: Pick from ROCm nightly
PR/PUSH(master/main/rel): Pick from last ROCm release Manual Trigger: Based on ROCm version
Local Build: Based on ROCm version if provided else latest nightly

## Test Plan

Check with PR/PUSH using this PR.
Check manual Trigger

## Test Result
