### PR TITLE
Fixed the lib path, removed node and user to secrets and removed level 3 tests

### DIFF
--- a/.github/workflows/README_NIGHTLY_TESTS.md
+++ b/.github/workflows/README_NIGHTLY_TESTS.md
@@ -4,11 +4,11 @@ This document describes [`.github/workflows/rvs-nightly-tests.yml`](./rvs-nightl
 which picks up the **latest RVS tarball** from the index URL configured in
 `vars.RVS_TARBALL_INDEX_URL` (e.g. `https://repo.amd.com/rocm/rvs/tarball/`)
 once per day, copies it to a **configurable remote target node** over SSH,
-installs it there, and runs RVS levels 3 and 4 on that node.
+installs it there, and runs RVS level 4 on that node.
 
 The GitHub Actions runner ("RVS Runner") is only an **orchestrator** — it
 doesn't need a GPU or ROCm installed locally. All RVS install, binary
-verification, and `rvs -r 3` / `rvs -r 4` execution happens on the target
+verification, and `rvs -r 4` execution happens on the target
 node. The target node is configurable so the same workflow can be pointed
 at any GPU host without code changes.
 
@@ -27,12 +27,11 @@ test        [GitHub runner = orchestrator]    ──ssh──▶  [target node =
     │  validate target_node / target_user                                         │
     │  write SSH key + config to $RUNNER_TEMP                                     │
     │  ssh rvs-target hostname; id                ─────────────────────────────▶  │ connectivity check
-    │  ssh rvs-target <prereq script>             ─────────────────────────────▶  │ /opt/rocm, rocm-smi, rocminfo, libs
+    │  ssh rvs-target <prereq script>             ─────────────────────────────▶  │ rocminfo + amd-smi version on $TARGET_ROCM_PATH
     │  curl <tarball URL>                         → ./pkg/<file>.tar.gz           │
     │  scp ./pkg/<file>.tar.gz rvs-target:…       ─────────────────────────────▶  │ $REMOTE_WORK_DIR/pkg/
     │  ssh rvs-target <install script>            ─────────────────────────────▶  │ sudo -n tar -xzf → /opt/rocm/extras-<N>/
     │  ssh rvs-target <ldd script>                ─────────────────────────────▶  │ verify RVS lib resolution
-    │  ssh rvs-target rvs -r 3                    ─────────────────────────────▶  │ writes $REMOTE_WORK_DIR/reports/rvs_level_3.log
     │  ssh rvs-target rvs -r 4                    ─────────────────────────────▶  │ writes $REMOTE_WORK_DIR/reports/rvs_level_4.log
     │  scp rvs-target:…/reports/*.log ./reports/  ◀─────────────────────────────  │
     │  build Markdown SUMMARY.md                  → GitHub job summary + artifact │
@@ -57,10 +56,10 @@ adjust the cron string in the workflow if your publish cadence is different.
 |---|---|---|
 | `tarball_url` | _(empty)_ | If set, the workflow downloads this exact URL instead of scraping the index. Useful for re-running an older build. |
 | `force` | `false` | When `true`, runs even if the latest tarball filename matches the cached marker. |
-| `target_node` | _(empty → `vars.RVS_TARGET_NODE`)_ | Hostname or IP of the node to install RVS on and run tests against. **This is the variable that retargets the test execution.** |
-| `target_user` | _(empty → `vars.RVS_TARGET_USER`; if both are unset, SSH defaults to the orchestrator runner's local user)_ | SSH user on the target node. Must have `NOPASSWD` sudo on the target (see prerequisites). |
+| `target_node` | _(empty → `secrets.RVS_TARGET_NODE`)_ | Hostname or IP of the node to install RVS on and run tests against. **This is the value that retargets the test execution.** Stored as a secret so the lab node identity isn't visible in repo settings or run logs (GitHub Actions automatically masks secret values as `***` in step output). |
+| `target_user` | _(empty → `secrets.RVS_TARGET_USER`; if both are unset, SSH defaults to the orchestrator runner's local user)_ | SSH user on the target node. Must have `NOPASSWD` sudo on the target (see prerequisites). Stored as a secret so the lab account name isn't visible in repo settings or run logs (GitHub Actions automatically masks secret values as `***` in step output). |
 | `remote_work_dir` | _(empty → `vars.RVS_REMOTE_WORK_DIR`, then `/tmp/rvs-nightly-<run_id>`)_ | Working dir on the target node where the tarball is staged, logs are written, and which gets `rm -rf`'d at the end. |
-| `target_rocm_path` | _(empty → `vars.RVS_TARGET_ROCM_PATH`, then `/opt/rocm`)_ | Which ROCm install on the target node to run RVS against. Could be the default `/opt/rocm`, a versioned `/opt/rocm-<ver>/` (only present on hosts that use the AMD multi-ROCm apt repos), or a TheRock-style tarball install rooted anywhere (e.g. `$HOME/<wherever>/install`). RVS is installed into `<this>/extras-<major>/` and the prereq tools probe under `<this>`. |
+| `target_rocm_path` | _(empty → `vars.RVS_TARGET_ROCM_PATH`)_ — **required**, no hard-coded default | Absolute path to the ROCm tarball install root on the target node. This is the directory containing `bin/rocminfo`, `bin/amd-smi`, `lib/`, `lib/llvm/lib/`, and `lib/rocm_sysdeps/lib/` (the layout produced by the ROCm tarball install method). The workflow fails fast in the validate step if neither the input nor the variable is set. |
 
 Workflow inputs **win over repo variables**, so individual `workflow_dispatch`
 runs can be retargeted from the Actions UI without changing repo settings.
@@ -96,16 +95,16 @@ gh workflow run rvs-nightly-tests.yml \
 | Name | Required? | Purpose |
 |---|---|---|
 | `RVS_TARBALL_INDEX_URL` | **Required** | Directory listing scraped for the latest tarball, e.g. `https://repo.amd.com/rocm/rvs/tarball/`. No fallback — the workflow fails fast if unset and no `tarball_url` input is supplied. |
-| `RVS_TARGET_NODE` | **Required** *(unless every run sets `target_node` input)* | Default hostname/IP of the node where RVS is installed and tests run. Workflow fails fast on `schedule` if neither this var nor `target_node` input is set. |
-| `RVS_TARGET_USER` | optional (no hard-coded default) | SSH user on the target node. If unset and `target_user` input is empty, the SSH client falls back to the orchestrator runner's local user — set this var explicitly to avoid surprises. |
 | `RVS_REMOTE_WORK_DIR` | optional (default `/tmp/rvs-nightly-<run_id>`) | Working dir on the target node. Cleared with `rm -rf` at the end of the job. |
-| `RVS_TARGET_ROCM_PATH` | optional (default `/opt/rocm`) | ROCm install on the target node that RVS should run against. Set this when `/opt/rocm` isn't what you want — e.g. when running against a versioned `/opt/rocm-<ver>/` on a multi-ROCm-package host, or a TheRock-style tarball install under `$HOME`. The `Verify RVS binary library resolution` step fails fast if any lib resolves from a different ROCm install. |
+| `RVS_TARGET_ROCM_PATH` | **Required** *(unless every run sets `target_rocm_path` input)* | Absolute path to the ROCm tarball install root on the target node — the directory that contains `bin/rocminfo`, `bin/amd-smi`, `lib/`, `lib/llvm/lib/`, and `lib/rocm_sysdeps/lib/`. The workflow doesn't assume any conventional path (no `/opt/rocm` default), since tarball installs land wherever you extracted them. |
 | `RVS_TEST_RUNNER_LABEL` | optional (default `self-hosted`) | Label of the GitHub runner that orchestrates the workflow. The runner doesn't need a GPU or ROCm — it just needs `ssh`, `scp`, and `curl`. |
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets):
 
 | Name | Required? | Purpose |
 |---|---|---|
+| `RVS_TARGET_NODE` | **Required** *(unless every run sets `target_node` input)* | Hostname or IP of the node where RVS is installed and tests run. Stored as a secret so the lab node identity isn't visible in repo Variables or in run logs — GitHub Actions automatically masks secret values as `***` wherever they appear in step output. Workflow fails fast on `schedule` if neither this secret nor `target_node` input is set. |
+| `RVS_TARGET_USER` | optional (no hard-coded default) | SSH user on the target node. If unset and `target_user` input is empty, the SSH client falls back to the orchestrator runner's local user — set this secret explicitly to avoid surprises. Stored as a secret so the lab account name isn't visible in repo settings or run logs (auto-masked as `***`). |
 | `RVS_TARGET_SSH_KEY` | **Required** | Private SSH key (OpenSSH or PEM format) authorized on the target node for `RVS_TARGET_USER`. Written to `$RUNNER_TEMP/rvs_target_key` for the duration of the job and scrubbed in the cleanup step. |
 
 ## How the latest tarball is picked
@@ -138,39 +137,57 @@ etc., and any version inside `7.x` without code changes:
 # On the runner (Validate target node configuration step):
 # Parsed from $TARBALL_NAME via [[ "$TARBALL_NAME" =~ ^amdrocm([0-9]+)- ]]
 ROCM_MAJOR=7
-# TARGET_ROCM_PATH comes from inputs.target_rocm_path / vars.RVS_TARGET_ROCM_PATH
-# (default: /opt/rocm).
-INSTALL_DIR=${TARGET_ROCM_PATH}/extras-${ROCM_MAJOR}   # <ROCM_INSTALL_PATH>/extras-7
+# INSTALL_DIR is always /opt/rocm/extras-<major>/ — it's where the RVS
+# tarball gets extracted. This is decoupled from TARGET_ROCM_PATH so the
+# install location matches the manual command verbatim regardless of
+# which ROCm install the workflow is told to run *against*.
+INSTALL_DIR=/opt/rocm/extras-${ROCM_MAJOR}              # /opt/rocm/extras-7
 RVS_BIN=${INSTALL_DIR}/bin/rvs
 
+# TARGET_ROCM_PATH (from inputs.target_rocm_path / vars.RVS_TARGET_ROCM_PATH;
+# required, no default) is *where the ROCm runtime libraries live*. Set
+# the repo variable to the absolute install root of the ROCm tarball you
+# want RVS to run against (the directory that contains bin/, lib/, etc.).
+
 # On the target node (Install RVS on target node step), via SSH:
-# sudo is used only when $INSTALL_DIR isn't user-writable (e.g. under
-# /opt/rocm-*). For TheRock tarball installs in $HOME, plain mkdir/tar is used.
+# sudo is used only when $INSTALL_DIR isn't user-writable. /opt/rocm/* is
+# typically root-owned so this picks up sudo -n automatically.
 mkdir -p "$INSTALL_DIR"     # (with `sudo -n` if needed)
 tar -xzf "$REMOTE_WORK_DIR/pkg/<tarball>.tar.gz" -C "$INSTALL_DIR"
 
-# LD_LIBRARY_PATH for the rvs binary is currently HARDCODED to match the
-# layout the RVS team uses manually. If you point target_rocm_path at a
-# non-/opt/rocm install (e.g. TheRock under $HOME), update the literal
-# strings in the workflow's install / verify-ldd / level-3 / level-4 /
-# report steps to match — see the "Hardcoded LD_LIBRARY_PATH" note below.
-export LD_LIBRARY_PATH="/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:${LD_LIBRARY_PATH:-}"
+# LD_LIBRARY_PATH is wired off INSTALL_DIR (for RVS's own libs) plus the
+# three TheRock-style subdirs of TARGET_ROCM_PATH (matches the official
+# ROCm tarball-install docs). This is what makes a non-/opt/rocm
+# TARGET_ROCM_PATH actually do something useful.
+export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
 
 "$RVS_BIN" --version
 ```
 
-### Hardcoded `LD_LIBRARY_PATH` (current temporary state)
+### Install location vs. ROCm runtime path
 
-To stay 1:1 with the manual sequence the RVS team uses today, the workflow
-hardcodes the runtime `LD_LIBRARY_PATH` for every step that executes the
-`rvs` binary (install, ldd-verify, level 3, level 4, and the report's
-`--version` query) to exactly:
+Two paths in the workflow look similar but mean very different things, and
+keeping them straight is what made the multi-ROCm-host case finally work:
+
+| Variable | What it is | Default | How to override |
+|---|---|---|---|
+| `INSTALL_DIR` | Where the RVS tarball gets extracted on the target node. Always under `/opt/rocm/`, matching the manual command. | `/opt/rocm/extras-${ROCM_MAJOR}` | Not configurable by design — the install location is canonical, decoupled from where ROCm itself lives. |
+| `TARGET_ROCM_PATH` | Where the ROCm runtime libraries live (the directory containing `bin/`, `lib/`, `lib/llvm/lib/`, `lib/rocm_sysdeps/lib/`). Drives `LD_LIBRARY_PATH`, the prereq-check probe, and the version row in the report. | **(no default — required)** | `inputs.target_rocm_path` (workflow_dispatch) or `vars.RVS_TARGET_ROCM_PATH` (repo Variables tab). Workflow fails fast in the validate step if neither is set. |
+
+This split exists because hosts that have multiple ROCm installs side-by-side
+(or that installed ROCm via a TheRock tarball under `$HOME`) almost never
+keep the runtime libs at `/opt/rocm/lib/`. The workflow needs to know where
+`/lib/`, `/lib/llvm/lib/`, and `/lib/rocm_sysdeps/lib/` actually are; the
+install location of RVS itself should not — and does not — care.
+
+The runtime `LD_LIBRARY_PATH` for every step that executes `rvs` (install,
+ldd-verify, level 4, report `--version` query) is now:
 
 ```bash
-LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:$LD_LIBRARY_PATH
+LD_LIBRARY_PATH=$INSTALL_DIR/lib:$TARGET_ROCM_PATH/lib/rocm_sysdeps/lib:$TARGET_ROCM_PATH/lib/llvm/lib:$TARGET_ROCM_PATH/lib:$LD_LIBRARY_PATH
 ```
 
-That mirrors the manual flow:
+Mapping back to the manual sequence the RVS team uses today:
 
 ```bash
 sudo mkdir -p /opt/rocm/extras-7
@@ -178,42 +195,20 @@ sudo tar -xzf amdrocm7-rvs-1.4.21-288-Linux.tar.gz -C /opt/rocm/extras-7
 export LD_LIBRARY_PATH=/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:$LD_LIBRARY_PATH
 ```
 
-Consequences and trade-offs:
+| Manual entry | Workflow equivalent | Notes |
+|---|---|---|
+| `/opt/rocm/extras-7/lib` | `${INSTALL_DIR}/lib` | Same path — `INSTALL_DIR` is literally `/opt/rocm/extras-<major>`. |
+| `/install/lib` | `${TARGET_ROCM_PATH}/lib` | The manual command's `/install/` was a literal filesystem path that only existed on the RVS build container. The workflow replaces it with the configurable `TARGET_ROCM_PATH/lib`, which is what "the ROCm install's lib directory" actually means on a real host. |
+| `/install/lib/rocm_sysdeps/` | `${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib` | Same fix, plus the trailing `/lib` that the official ROCm tarball docs include and the manual command was missing. |
+| `/install/lib/llvm/lib` | `${TARGET_ROCM_PATH}/lib/llvm/lib` | Where `libomp.so` lives in TheRock builds. |
 
-- The default `target_rocm_path=/opt/rocm` case "just works" — `INSTALL_DIR` resolves to `/opt/rocm/extras-7`, which is exactly what the hardcoded path points at.
-- If you set `target_rocm_path` to something else (a versioned `/opt/rocm-<ver>/` or a TheRock home-dir install), RVS will install into the new path but the hardcoded `LD_LIBRARY_PATH` will still point at `/opt/rocm/extras-7/lib`. The `Verify RVS binary library resolution` step will catch this and fail with a clear error listing the offending paths — so it's loud, not silent. To actually retarget at a different ROCm, edit the five `LD_LIBRARY_PATH=` lines in `.github/workflows/rvs-nightly-tests.yml` (grep for `/opt/rocm/extras-7/lib`) to the corresponding paths under the new install.
-- This is a deliberate temporary state. When the team is ready for full multi-ROCm support, replace those five literals with `"${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${INSTALL_DIR}/lib/rocm_sysdeps/lib:${INSTALL_DIR}/lib:${LD_LIBRARY_PATH:-}"` — the prereq-check step already uses that dynamic form as a reference.
+### What to set `RVS_TARGET_ROCM_PATH` to
 
-### Multi-ROCm hosts (`/opt/rocm-<ver1>`, `/opt/rocm-<ver2>`, …)
+Set it to the absolute path of the ROCm **tarball install root** on the target node — i.e. the directory you (or whoever provisioned the node) chose when extracting the ROCm distribution tarball. That directory must contain at least `bin/rocminfo`, `bin/amd-smi`, `lib/`, `lib/llvm/lib/`, and `lib/rocm_sysdeps/lib/`. There is no hard-coded default; the workflow fails fast in the validate step if `RVS_TARGET_ROCM_PATH` and the per-run `target_rocm_path` input are both empty.
 
-When the target node has several versioned ROCm installs side-by-side,
-`/opt/rocm` is typically a symlink to one of them and the RVS binary's
-RUNPATH resolves to `/opt/rocm/lib`. Without `target_rocm_path`/
-`RVS_TARGET_ROCM_PATH`, the dynamic linker will silently pull libraries
-from whichever ROCm the symlink happens to point at — which may not be
-the one you want to test. Symptom: `ldd $RVS_BIN` shows paths like
-`/opt/rocm-<wrong-ver>/lib/libamd_smi.so.<N>` when you expected a different version.
+The RVS tarball itself still always lands in `/opt/rocm/extras-<major>/` regardless — that part is invariant.
 
-Find the right path on the node:
-
-```bash
-ssh <USER>@<HOST_OR_IP> '
-  ls -d /opt/rocm* 2>/dev/null
-  echo "/opt/rocm -> $(readlink /opt/rocm 2>/dev/null || echo "(not a symlink)")"
-  for d in /opt/rocm-*; do
-    v=$(cat "$d/.info/version" 2>/dev/null || echo "?")
-    printf "  %-30s version=%s\n" "$d" "$v"
-  done
-'
-```
-
-Then either set `vars.RVS_TARGET_ROCM_PATH=<ROCM_INSTALL_PATH>` once for
-all runs, or pass `-f target_rocm_path=<ROCM_INSTALL_PATH>` for a single
-dispatch. The workflow's `Verify RVS binary library resolution` step
-explicitly fails the job if any resolved library lives in a `/opt/rocm-*`
-other than `TARGET_ROCM_PATH`, so cross-contamination can't go unnoticed.
-
-### TheRock-style tarball ROCm installs (no `/opt/rocm-<ver>`)
+### TheRock-style tarball ROCm installs
 
 The [official ROCm 7.12+ "tarball" install method](https://rocm.docs.amd.com/en/7.12.0-preview/install/rocm.html?fam=instinct&gpu=mi350x&os=ubuntu&os-version=24.04&i=tar)
 doesn't drop ROCm under `/opt/rocm-<ver>/`. Instead you extract a
@@ -252,12 +247,10 @@ This works with the workflow as-is, with two things to be aware of:
 What the workflow handles automatically for tarball installs:
 
 - The install step **skips `sudo`** when the destination is user-writable (TheRock installs in `$HOME` don't need root); only system `/opt/rocm-*` installs trigger `sudo -n`.
-- The prereq check uses whatever `rocm-smi` / `rocminfo` are first on `PATH` (system package installs land them in `/usr/bin/`; versioned installs typically register them via `/etc/profile.d/rocm.sh`). The binaries' RPATH locates the matching ROCm runtime libs, so no `LD_LIBRARY_PATH` setup is needed for the prereq tools.
-- Tarball installs typically don't ship a `.info/version` file, so the version-string row in the report may show `unknown` — the major-version cross-check is automatically skipped in that case (no false failure).
+- The prereq check invokes `${TARGET_ROCM_PATH}/bin/rocminfo` and `${TARGET_ROCM_PATH}/bin/amd-smi version` directly by absolute path. TheRock tarball binaries have RPATH/RUNPATH baked in relative to `${TARGET_ROCM_PATH}/lib`, so they resolve their own ROCm libs without needing `PATH` or `LD_LIBRARY_PATH` setup.
+- The version-string row in the report uses what `rvs --version` prints, so it always reflects the RVS tarball — not the underlying ROCm. The major-version cross-check the workflow used to do against `.info/version` is gone (TheRock installs don't ship one).
 
-**What you have to do manually right now** to actually run RVS against a TheRock-style install:
-
-Because `LD_LIBRARY_PATH` for the rvs binary itself is currently [hardcoded](#hardcoded-ld_library_path-current-temporary-state) to `/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:...`, simply pointing `target_rocm_path` at a tarball install root is **not enough** — RVS will install into the right place, but the loader won't see the libs and the `Verify RVS binary library resolution` step will hard-fail. To use a non-`/opt/rocm` ROCm install today, edit the five `LD_LIBRARY_PATH=` literals in `.github/workflows/rvs-nightly-tests.yml` (grep for `/opt/rocm/extras-7/lib`) to point at the matching paths under your install. Or revert those literals to the dynamic form documented above so the workflow follows `TARGET_ROCM_PATH` automatically.
+**To use a TheRock-style install just set `vars.RVS_TARGET_ROCM_PATH` (or pass `-f target_rocm_path=...`) to the absolute install root, e.g. `$HOME/<wherever>/install`. The workflow's `LD_LIBRARY_PATH` is wired off `TARGET_ROCM_PATH` (see [Install location vs. ROCm runtime path](#install-location-vs-rocm-runtime-path)), so the loader picks up `lib/`, `lib/llvm/lib/`, and `lib/rocm_sysdeps/lib/` from the install you point at — no file edits required.
 
 `sudo -n` is non-interactive — it fails fast instead of hanging if
 `NOPASSWD` isn't configured. There's no PTY over the SSH channel anyway,
@@ -279,88 +272,83 @@ if `$RVS_BIN` isn't executable after extraction.
 **On the target node** (all enforced by the **Pre-flight ROCm checks** below — the workflow fails fast if any are missing):
 
 - SSH server reachable from the runner, with the public counterpart of `secrets.RVS_TARGET_SSH_KEY` authorized for `$TARGET_USER`.
-- `$TARGET_USER` has **`NOPASSWD` sudo** for `mkdir` + `tar` into `/opt/rocm/extras-<major>` — the install step uses `sudo -n` and aborts otherwise.
-- ROCm base stack already installed at `/opt/rocm/` with a major version that matches the tarball name (e.g. `amdrocm7-rvs-…` requires ROCm 7.x). The TGZ only ships RVS, not a full ROCm install; the RVS binary depends on ROCm libraries resolved via `RPATH` to the system ROCm.
-- Working kernel driver (`amdgpu`) and at least one GPU enumerated by `rocm-smi` and `rocminfo`.
+- `$TARGET_USER` has **`NOPASSWD` sudo** for `mkdir` + `tar` into `/opt/rocm/extras-<major>` — the install step uses `sudo -n` (when the path isn't user-writable) and aborts otherwise.
+- A ROCm tarball install at `$TARGET_ROCM_PATH` (configured via `vars.RVS_TARGET_ROCM_PATH` or the per-run `target_rocm_path` input) that provides at least `bin/rocminfo` and `bin/amd-smi`. The RVS tarball only ships RVS, not the rest of ROCm, so the runtime libs under `$TARGET_ROCM_PATH/lib`, `$TARGET_ROCM_PATH/lib/llvm/lib`, and `$TARGET_ROCM_PATH/lib/rocm_sysdeps/lib` must be present.
+- Working kernel driver (`amdgpu`) and at least one GPU enumerated by `rocminfo` / `amd-smi`.
 
 ## Pre-flight ROCm checks
 
-Before downloading or installing the tarball, the workflow runs **`Verify ROCm prerequisites on target node`** — the same checks as before, but executed remotely via SSH on the target node, not on the GitHub runner. The step accumulates failures and reports all of them in a single log so the cause is obvious:
+Before downloading or installing the tarball, the workflow runs **`Verify ROCm prerequisites on target node`** over SSH. It's deliberately minimal — two probes against the actual install at `$TARGET_ROCM_PATH`:
 
 | Sub-check | Action on failure | Catches |
 |---|---|---|
-| `$TARGET_ROCM_PATH` directory exists | hard fail (`exit 1`, also prints the available `/opt/rocm*` installs to ease debugging) | ROCm not installed on target, or the configured path is wrong (typo, point-release suffix mismatch, etc.) |
-| Read ROCm version from `$TARGET_ROCM_PATH/.info/version` (fallback `share/doc/rocm-core/version`) | warn if missing | Partial install, dev pkgs only |
-| Major version match (regex on tarball name vs target's ROCm version) | hard fail on mismatch | RVS-7 tarball pointed at a ROCm-6 install |
-| `rocm-smi --showid` runs and exits 0 | hard fail | `amdgpu` driver not loaded, or `rocm-smi` missing |
-| `rocminfo` enumerates ≥ 1 GPU | hard fail | "ROCm installed but no GPU exposed" (group/permissions, BIOS IOMMU, etc.) |
-| `libhsa-runtime64.so.1` and `libamdhip64.so` present in `ldconfig -p` | warn only | Covers both system-package installs (libs in `/usr/lib/x86_64-linux-gnu`) and properly-registered versioned `/opt/rocm-*` installs. Warn-only because TheRock-style tarball installs that aren't registered with `ldconfig` still resolve at runtime via the binaries' RPATH. |
+| `$TARGET_ROCM_PATH` directory exists | hard fail (`exit 1`) | ROCm not installed on target, or the configured path is wrong (typo, missing trailing component, etc.) |
+| `$TARGET_ROCM_PATH/bin/rocminfo` exits 0 | hard fail (via `set -euo pipefail`) | Driver not loaded, no GPU exposed, runtime libs under `$TARGET_ROCM_PATH/lib` missing/broken, group permissions wrong |
+| `$TARGET_ROCM_PATH/bin/amd-smi version` exits 0 | hard fail | `amd-smi` missing from the install, ROCm SMI library mismatch, or driver/runtime broken |
+
+Both binaries are invoked by absolute path (`${TARGET_ROCM_PATH}/bin/...`), so the workflow doesn't depend on `PATH` or `LD_LIBRARY_PATH` being set up — the binaries' baked-in RPATH/RUNPATH resolves the runtime libs from `${TARGET_ROCM_PATH}/lib`. If either probe fails, the step fails fast with the binary's own error message in the log, which is usually more diagnostic than anything the workflow could add on top.
 
 A typical successful log (with `target_rocm_path=<ROCM_INSTALL_PATH>`):
 
 ```
+=== System ===
+Linux <hostname> 6.x.x-x-generic ...
+
 === Target ROCm path: <ROCM_INSTALL_PATH> ===
-<ROCM_INSTALL_PATH> -> <ROCM_INSTALL_PATH>.<point-release>
-=== ROCm version (under <ROCM_INSTALL_PATH>) ===
-<ROCM_INSTALL_PATH>/.info/version : <ROCM_VERSION>
-=== Major version match (tarball vs target node) ===
-tarball expects ROCm major : 7
-target has ROCm major      : 7
-=== rocm-smi ===
-GPU[0]  : ID  : 0xXXXX
-=== rocminfo (GPU enumeration) ===
-GPU agents enumerated: <N>
-=== Key ROCm runtime libraries (via ldconfig) ===
-  OK    : libhsa-runtime64.so.1  (<some-resolved-path>/libhsa-runtime64.so.1)
-  OK    : libamdhip64.so  (<some-resolved-path>/libamdhip64.so)
-::notice::ROCm prerequisites OK on target node at <ROCM_INSTALL_PATH> (version <ROCM_VERSION>)
+
+=== <ROCM_INSTALL_PATH>/bin/rocminfo ===
+ROCk module version <X.Y> is loaded
+HSA Agents
+==========
+Agent 1
+  Name:                    AMD Instinct ...
+  ...
+Agent 2..N: (one per GPU)
+
+=== <ROCM_INSTALL_PATH>/bin/amd-smi version ===
+AMDSMI Tool: <X.Y.Z> | AMDSMI Library version: <X.Y.Z> | ROCm version: <ROCM_VERSION>
+
+::notice::ROCm prerequisites OK on target node at <ROCM_INSTALL_PATH>
 ```
 
-After install, **`Verify RVS binary library resolution on target node`** runs `ldd "$RVS_BIN"` over SSH (where `$RVS_BIN` = `${TARGET_ROCM_PATH}/extras-${ROCM_MAJOR}/bin/rvs`) and fails the job in two cases:
-
-- **Unresolved deps:** any library shows up as `not found` — prevents the workflow from spending hours on `rvs -r 3`/`-r 4` only to discover a `dlopen` error in the level log.
-- **Wrong-ROCm contamination:** any resolved library lives in a `/opt/rocm-<X>` whose `realpath` differs from `$TARGET_ROCM_PATH` (e.g. `ldd` shows a library under a different `/opt/rocm-<other-ver>/` than the one you targeted). The step prints which paths leaked and suggests setting `target_rocm_path` to fix it.
+After install, **`Verify RVS binary library resolution on target node`** runs `ldd "$RVS_BIN"` over SSH (where `$RVS_BIN` = `/opt/rocm/extras-${ROCM_MAJOR}/bin/rvs`) and **hard-fails** the job if any library shows up as `not found`. This prevents the workflow from spending hours on `rvs -r 4` only to discover a `dlopen` error in the level log. The full `ldd` output is printed for diagnostic purposes — useful for spotting which `$TARGET_ROCM_PATH/lib/...` paths each library resolved from.
 
 ### Manual one-liner (validate a candidate target node)
 
-To verify a node is viable before pointing the workflow at it, SSH into the candidate and run:
+To verify a node is viable before pointing the workflow at it, SSH into the candidate and run the same two probes the workflow runs (substituting `<ROCM_INSTALL_PATH>` with what you plan to set `target_rocm_path` to):
 
 ```bash
-set -uo pipefail
-[ -d /opt/rocm ] || { echo "no /opt/rocm"; exit 1; }
-echo "version: $(cat /opt/rocm/.info/version 2>/dev/null || \
-                 cat /opt/rocm/share/doc/rocm-core/version 2>/dev/null || \
-                 echo unknown)"
-rocm-smi --showid >/dev/null && echo "rocm-smi OK"
-N=$(rocminfo 2>/dev/null | grep -c 'Device Type:.*GPU' || echo 0)
-[ "$N" -ge 1 ] && echo "rocminfo OK ($N GPU agents)" || { echo "no GPU"; exit 1; }
-ldconfig -p | grep -q libhsa-runtime64.so.1 && echo "libhsa-runtime64 OK" || echo "warn: libhsa-runtime64 missing"
+ROCM_PATH=<ROCM_INSTALL_PATH>
+set -euo pipefail
+[ -d "$ROCM_PATH" ] || { echo "$ROCM_PATH does not exist"; exit 1; }
+"$ROCM_PATH/bin/rocminfo"
+"$ROCM_PATH/bin/amd-smi" version
 sudo -n true 2>/dev/null && echo "NOPASSWD sudo OK" || echo "warn: sudo requires password (install step will fail)"
 echo "Target node OK"
 ```
 
-## The tests
+If both `rocminfo` and `amd-smi version` exit zero, the workflow's prereq step will pass on this node.
+
+## The test
 
 Run verbatim on the target node (with `$RVS_BIN` = `/opt/rocm/extras-${ROCM_MAJOR}/bin/rvs`,
 populated by the validate step — for an `amdrocm7-…` tarball this resolves
 to `/opt/rocm/extras-7/bin/rvs`):
 
 ```bash
-"$RVS_BIN" -r 3
 "$RVS_BIN" -r 4
 ```
 
-Both commands are executed sequentially over SSH. Each step captures full
-stdout/stderr to `$REMOTE_WORK_DIR/reports/rvs_level_<N>.log` on the
-target, then the **`Collect logs from target node`** step `scp`s the
-`*.log` files back to `./reports/` on the runner. Each command's exit
-code is propagated through SSH and recorded in a step output. Neither
-failure short-circuits the other — both levels always run, and the job
-is marked failed at the end if either exited non-zero.
+The command is executed over SSH. The step captures full stdout/stderr to
+`$REMOTE_WORK_DIR/reports/rvs_level_4.log` on the target, then the
+**`Collect logs from target node`** step `scp`s the log file back to
+`./reports/` on the runner. The command's exit code is propagated through
+SSH and recorded in a step output, and the job is marked failed at the end
+if level 4 exited non-zero.
 
 ## Test report
 
-After both RVS commands finish and logs are collected, the `Build test report`
+After RVS finishes and the log is collected, the `Build test report`
 step generates `reports/SUMMARY.md` (also written to the GitHub job summary),
 e.g.:
 
@@ -384,7 +372,6 @@ e.g.:
 
 | Test    | Command                                              | Result | Exit | Started (UTC)         | Ended (UTC)           |
 |---------|------------------------------------------------------|:------:|-----:|-----------------------|-----------------------|
-| Level 3 | `/opt/rocm/extras-7/bin/rvs -r 3` (on `hostname`)      | PASS   |    0 | 2026-05-19T15:01:00Z  | 2026-05-19T15:25:11Z  |
 | Level 4 | `/opt/rocm/extras-7/bin/rvs -r 4` (on `hostname`)      | PASS   |    0 | 2026-05-19T15:25:12Z  | 2026-05-19T16:02:47Z  |
 ```
 
@@ -393,7 +380,6 @@ The full artifact contents:
 ```
 rvs-nightly-report-<run_id>/
 ├── SUMMARY.md
-├── rvs_level_3.log
 └── rvs_level_4.log
 ```
 
@@ -433,7 +419,7 @@ Watch the Actions tab for:
 5. **Verify ROCm prerequisites on target node** prints `::notice::ROCm prerequisites OK on target node at <TARGET_ROCM_PATH>`.
 6. **Install RVS on target node** prints the detected `ROCM_MAJOR`, the chosen `Target ROCm path`, and `Installed RVS at: <TARGET_ROCM_PATH>/extras-<N>/bin/rvs`.
 7. **Verify RVS binary library resolution on target node** prints `::notice::RVS binary's library dependencies resolved OK on target, all from <TARGET_ROCM_PATH>`.
-8. Two RVS level steps complete; the run summary shows the results table with both **Orchestrator** and **Target node** rows.
+8. RVS level 4 step completes; the run summary shows the results table with both **Orchestrator** and **Target node** rows.
 
 ## Debugging a failed run
 
@@ -442,21 +428,21 @@ Watch the Actions tab for:
 | `detect` job exits with `vars.RVS_TARBALL_INDEX_URL is not set` | The required variable is unset. Set it in the repo Variables (e.g. to `https://repo.amd.com/rocm/rvs/tarball/`), or pass `tarball_url` via `workflow_dispatch`. |
 | `detect` job exits with "Could not resolve a tarball URL" | The index page returned no matches. Verify the URL in `vars.RVS_TARBALL_INDEX_URL` returns at least one `amdrocm*-rvs-*-Linux.tar.gz` link. |
 | `test` job stuck "Queued" | No orchestrator runner online with the label in `vars.RVS_TEST_RUNNER_LABEL`. |
-| **Validate target node configuration** fails: `No target node configured` | Neither `inputs.target_node` nor `vars.RVS_TARGET_NODE` is set. Set the variable, or pass `target_node` via `workflow_dispatch`. |
+| **Validate target node configuration** fails: `No target node configured` | Neither `inputs.target_node` nor `secrets.RVS_TARGET_NODE` is set. Add the secret in Settings → Secrets and variables → Actions → Secrets, or pass `target_node` via `workflow_dispatch`. |
 | **Setup SSH key for target node** fails: `secrets.RVS_TARGET_SSH_KEY is not set` | The required secret is missing. Add the private SSH key as a repo secret. |
 | **Setup SSH key for target node** fails: `Permission denied (publickey)` | The key in `RVS_TARGET_SSH_KEY` isn't authorized on the target node for `$TARGET_USER`, or the key format is wrong. Verify by `ssh -i <key> $TARGET_USER@$TARGET_NODE hostname` from a workstation. |
 | **Setup SSH key for target node** fails: `Connection timed out` / `Connection refused` | Network reachability problem between the orchestrator runner and the target node. Check firewall / VPN / bastion routing. |
 | **Setup SSH key for target node** fails: `Host key verification failed` | `ssh-keyscan` couldn't pre-seed the key and `accept-new` rejected it (rare). Remove any stale entry for the target in the runner's `known_hosts`, or pre-populate it manually. |
-| **Verify ROCm prerequisites on target node** fails: `<TARGET_ROCM_PATH> does not exist on the target node` | The configured `target_rocm_path` / `vars.RVS_TARGET_ROCM_PATH` doesn't point at a real directory on the target. The step prints all `/opt/rocm*` installs that *do* exist — pick one of those (or fix the symlink). |
-| **Verify ROCm prerequisites on target node** fails: `ROCm major version mismatch` | The tarball is for ROCm `<X>` but `$TARGET_ROCM_PATH` is a ROCm `<Y>` install. Either pin a matching tarball with `tarball_url`, or change `target_rocm_path`. |
-| **Verify RVS binary library resolution on target node** fails: `RVS is resolving libraries from a ROCm install OTHER than ...` | RVS picked up libraries from a different ROCm than the one you targeted (typical on hosts where `/opt/rocm` symlinks to the "wrong" version). The step lists the offending paths. Set `target_rocm_path` to the specific install path you want (a versioned `/opt/rocm-<ver>/` on multi-rocm-package hosts, or a tarball install root). |
-| **Verify ROCm prerequisites on target node** fails: `rocm-smi … exited non-zero` | `amdgpu` kernel driver is not loaded on the target. SSH in and `lsmod \| grep amdgpu`, then `sudo modprobe amdgpu` and check `dmesg`. |
-| **Verify ROCm prerequisites on target node** fails: `rocminfo enumerated 0 GPU agents` | Driver loaded but no GPU exposed to `$TARGET_USER`. Add the user to `video` and `render` groups, log out and back in. |
+| **Verify ROCm prerequisites on target node** fails: `<TARGET_ROCM_PATH> does not exist on the target node` | The configured `target_rocm_path` / `vars.RVS_TARGET_ROCM_PATH` doesn't point at a real directory on the target. Verify by `ssh <USER>@<HOST_OR_IP> 'ls -d <TARGET_ROCM_PATH>'`. |
+| **Verify ROCm prerequisites on target node** fails: `<TARGET_ROCM_PATH>/bin/rocminfo: No such file or directory` | The install at `$TARGET_ROCM_PATH` is incomplete — missing `bin/rocminfo`. Either pick a different `target_rocm_path` (one that contains a complete ROCm distribution) or reinstall ROCm at the configured path. |
+| **Verify ROCm prerequisites on target node** fails: `rocminfo` exits non-zero | Driver issue or runtime libs missing. Common causes: `amdgpu` kernel driver not loaded (`lsmod \| grep amdgpu`, then `sudo modprobe amdgpu` and check `dmesg`); `$TARGET_USER` not in `video`/`render` groups; `$TARGET_ROCM_PATH/lib` missing or broken. The `rocminfo` error message in the log usually pinpoints the cause. |
+| **Verify ROCm prerequisites on target node** fails: `amd-smi version` exits non-zero | Either `amd-smi` is missing from `$TARGET_ROCM_PATH/bin/`, or the AMDSMI library under `$TARGET_ROCM_PATH/lib` is broken/missing. Reinstall or repoint `target_rocm_path` at a complete install. |
+| **Verify RVS binary library resolution on target node** fails: `RVS binary has unresolved library dependencies on target` | One or more libraries showed up as `not found` in `ldd` output. The `LD_LIBRARY_PATH` (built from `$INSTALL_DIR/lib` + `$TARGET_ROCM_PATH/{lib,lib/llvm/lib,lib/rocm_sysdeps/lib}`) didn't have them, RUNPATH didn't have them, and `ldconfig` didn't have them either. Usually means `$TARGET_ROCM_PATH` is incomplete (missing libraries under `lib/`, `lib/llvm/lib/`, or `lib/rocm_sysdeps/lib/`). The step's `ldd` output above the error names the specific missing library. |
 | **Install RVS on target node** fails: `Cannot parse ROCm major version from tarball name` | The tarball doesn't match `^amdrocm<digits>-`. Either pin a correctly-named tarball with `tarball_url`, or fix the upstream filename. |
 | **Install RVS on target node** fails: `sudo: a password is required` | `$TARGET_USER` doesn't have `NOPASSWD` sudo on the target. Add a sudoers entry permitting `mkdir` and `tar` into `$TARGET_ROCM_PATH/extras-*` without a password. |
 | **Install RVS on target node** fails: `rvs binary not found or not executable at <TARGET_ROCM_PATH>/extras-<N>/bin/rvs after install` | The tarball isn't rooted at `./bin/`, `./lib/`, etc. The extraction landed `bin/rvs` somewhere else inside `$TARGET_ROCM_PATH/extras-<N>/`. Inspect the step log (`ls -la` output) to see the actual layout; the workflow may need `--strip-components=<N>` added to the `tar` invocation. |
 | **Verify RVS binary library resolution on target node** fails with `not found` | A ROCm runtime library is missing or not in `RPATH` on the target. The step prints the `ldd` output; install the matching ROCm component (typically `rocm-llvm`, `rocm-core`, `hip-runtime-amd`). |
-| **Run RVS level N on target node** exits non-zero immediately (after both verify steps passed) | RVS plugin's own dependency missing on the target (e.g. `libpci3` on Debian). Check the level log for the specific error. |
+| **Run RVS level 4 on target node** exits non-zero immediately (after both verify steps passed) | RVS plugin's own dependency missing on the target (e.g. `libpci3` on Debian). Check `rvs_level_4.log` in the artifact for the specific error. |
 | **Collect logs from target node** warns: `No log files retrieved from target node` | The level steps exited so early they didn't produce any output, or `$REMOTE_WORK_DIR` was wiped. Inspect the level-step logs in the run UI for the original error. |
 | Cron skipped a day | GitHub may delay or drop schedules under high load. Run once manually with `force=true` to validate. |
 
@@ -464,14 +450,14 @@ Watch the Actions tab for:
 
 There are three ways to point the workflow at a different node, in increasing order of permanence:
 
-1. **Single run, from the Actions UI:** Run workflow → fill in `target_node` (and optionally `target_user` / `remote_work_dir` / `target_rocm_path`). Anything left blank falls back to the matching repo variable. `target_node` has no hard-coded default (workflow fails fast), `target_user` falls through to the orchestrator runner's local user, `remote_work_dir` falls through to `/tmp/rvs-nightly-<run_id>`, and `target_rocm_path` falls through to `/opt/rocm`. This is the right path for "test this tarball on host X today".
+1. **Single run, from the Actions UI:** Run workflow → fill in `target_node` and `target_rocm_path` (and optionally `target_user` / `remote_work_dir`). Anything left blank falls back to the matching repo configuration value — `target_node` and `target_user` read from the **secrets** `RVS_TARGET_NODE` / `RVS_TARGET_USER` (both masked as `***` in run logs); `target_rocm_path` / `remote_work_dir` read from repo Variables. `target_node` and `target_rocm_path` have no hard-coded defaults — the workflow fails fast if neither input nor stored value is set for either. `target_user` falls through to the orchestrator runner's local user; `remote_work_dir` falls through to `/tmp/rvs-nightly-<run_id>`.
 2. **Single run, from `gh` CLI:**
    ```bash
    gh workflow run rvs-nightly-tests.yml \
      -f target_node="<host-or-ip>" \
-     -f target_rocm_path="<ROCM_INSTALL_PATH>"   # only needed on multi-ROCm hosts
+     -f target_rocm_path="<ROCM_INSTALL_PATH>"
    ```
-3. **Permanent change:** update repo variable `RVS_TARGET_NODE` (and optionally `RVS_TARGET_USER` / `RVS_REMOTE_WORK_DIR` / `RVS_TARGET_ROCM_PATH`). All subsequent scheduled and manual runs will pick this up unless an input overrides it.
+3. **Permanent change:** update repo secrets `RVS_TARGET_NODE` / `RVS_TARGET_USER` and repo variable `RVS_TARGET_ROCM_PATH` (and optionally repo variable `RVS_REMOTE_WORK_DIR`). All subsequent scheduled and manual runs will pick these up unless an input overrides them.
 
 The same `RVS_TARGET_SSH_KEY` secret is reused across nodes — make sure the
 public counterpart of that key is added to `$TARGET_USER`'s `~/.ssh/authorized_keys`

--- a/.github/workflows/rvs-nightly-tests.yml
+++ b/.github/workflows/rvs-nightly-tests.yml
@@ -2,11 +2,11 @@ name: RVS Nightly Tests
 
 # Picks up the latest RVS tarball published at the index URL configured in
 # vars.RVS_TARBALL_INDEX_URL once per day, copies it to a configurable target
-# node, installs it there, runs RVS levels 3 and 4 on that node, and uploads a
-# Markdown report + per-level logs as an artifact from the GitHub runner.
+# node, installs it there, runs RVS level 4 on that node, and uploads a
+# Markdown report + per-level log as an artifact from the GitHub runner.
 #
 # The GitHub Actions runner ("RVS Runner") only orchestrates. All RVS install,
-# binary verification, and rvs -r 3 / -r 4 execution happens on the target node
+# binary verification, and rvs -r 4 execution happens on the target node
 # reached over SSH. The target node is configurable so the same workflow can be
 # pointed at any GPU host without code changes.
 #
@@ -14,14 +14,23 @@ name: RVS Nightly Tests
 # ---------------------------
 # Variables (Settings → Secrets and variables → Actions → Variables):
 #   RVS_TARBALL_INDEX_URL  HTTP listing the published amdrocm*-rvs-*.tar.gz files.
-#   RVS_TARGET_NODE        Default hostname/IP of the node that runs RVS.
-#                          Can be overridden per-run via workflow_dispatch input.
-#   RVS_TARGET_USER        (Optional) SSH user on the target node.
 #   RVS_REMOTE_WORK_DIR    (Optional) Working dir on the target node.
 #                          Default: /tmp/rvs-nightly-<run_id>.
+#   RVS_TARGET_ROCM_PATH   Default absolute path to the ROCm tarball install
+#                          root on the target node. Can be overridden per-run
+#                          via workflow_dispatch input target_rocm_path.
 #   RVS_TEST_RUNNER_LABEL  (Optional) Label of the GitHub runner. Default: self-hosted.
 #
 # Secrets (Settings → Secrets and variables → Actions → Secrets):
+#   RVS_TARGET_NODE        Default hostname/IP of the node that runs RVS. Stored
+#                          as a secret to avoid leaking the lab node identity in
+#                          repo settings / run logs (only the workflow accesses
+#                          it). Can be overridden per-run via workflow_dispatch
+#                          input target_node.
+#   RVS_TARGET_USER        (Optional) SSH user on the target node. Stored as a
+#                          secret so the lab account name isn't visible in repo
+#                          settings or run logs. Can be overridden per-run via
+#                          workflow_dispatch input target_user.
 #   RVS_TARGET_SSH_KEY     Private SSH key (in PEM/OpenSSH format) authorized on
 #                          the target node for RVS_TARGET_USER. The user on the
 #                          target node must have NOPASSWD sudo for installs into
@@ -42,11 +51,11 @@ on:
         type: boolean
         default: false
       target_node:
-        description: 'Hostname/IP of node to install RVS on and run tests (default: vars.RVS_TARGET_NODE)'
+        description: 'Hostname/IP of node to install RVS on and run tests (default: secrets.RVS_TARGET_NODE)'
         required: false
         default: ''
       target_user:
-        description: 'SSH user on the target node (default: vars.RVS_TARGET_USER)'
+        description: 'SSH user on the target node (default: secrets.RVS_TARGET_USER)'
         required: false
         default: ''
       remote_work_dir:
@@ -54,7 +63,7 @@ on:
         required: false
         default: ''
       target_rocm_path:
-        description: 'ROCm install dir on the target node to run RVS against, e.g. a versioned /opt/rocm-<ver> or a tarball install root (default: vars.RVS_TARGET_ROCM_PATH or /opt/rocm)'
+        description: 'ROCm tarball install root on the target node to run RVS against (default: vars.RVS_TARGET_ROCM_PATH)'
         required: false
         default: ''
 
@@ -157,7 +166,7 @@ jobs:
           key: rvs-nightly-tarball-${{ steps.resolve.outputs.tarball_name }}
 
   test:
-    name: Install RVS and run levels 3 + 4 (on remote target node)
+    name: Install RVS and run level 4 (on remote target node)
     needs: detect
     if: needs.detect.outputs.should_run == 'true'
     runs-on: ${{ vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
@@ -167,14 +176,16 @@ jobs:
       TARBALL_NAME: ${{ needs.detect.outputs.tarball_name }}
       # Target node where install + tests actually run. Inputs win over repo vars
       # so individual runs can be retargeted via workflow_dispatch.
-      TARGET_NODE:  ${{ inputs.target_node || vars.RVS_TARGET_NODE }}
-      TARGET_USER:  ${{ inputs.target_user || vars.RVS_TARGET_USER }}
-      # ROCm install on the target node that RVS should run against. Lets the
-      # workflow target a specific ROCm install (a versioned /opt/rocm-<ver> on
-      # multi-rocm-package hosts, or a tarball install root anywhere) when the
-      # default /opt/rocm isn't what you want. Single-ROCm hosts can leave it
-      # at the default.
-      TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RVS_TARGET_ROCM_PATH || '/opt/rocm' }}
+      TARGET_NODE:  ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
+      TARGET_USER:  ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
+      # ROCm tarball install root on the target node that RVS should run
+      # against. This is the directory containing bin/, lib/, lib/llvm/lib/,
+      # lib/rocm_sysdeps/lib/, etc. (as produced by the ROCm tarball install
+      # method). Set vars.RVS_TARGET_ROCM_PATH to the absolute path of that
+      # install on the target node, or pass target_rocm_path per-run. No
+      # default — the validate step fails fast if neither is set, since
+      # there is no sensible system-wide default for tarball installs.
+      TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RVS_TARGET_ROCM_PATH }}
       # SSH_KEY_FILE / SSH_CONFIG_FILE are derived from $RUNNER_TEMP in the
       # validate step and exported via $GITHUB_ENV so every subsequent step
       # inherits them. We can't reference runner.temp here because the
@@ -188,7 +199,12 @@ jobs:
           set -euo pipefail
 
           if [ -z "${TARGET_NODE:-}" ]; then
-            echo "::error::No target node configured. Set workflow_dispatch input 'target_node' or repo variable 'RVS_TARGET_NODE'."
+            echo "::error::No target node configured. Set workflow_dispatch input 'target_node' or repo secret 'RVS_TARGET_NODE'."
+            exit 1
+          fi
+
+          if [ -z "${TARGET_ROCM_PATH:-}" ]; then
+            echo "::error::No ROCm tarball install root configured. Set workflow_dispatch input 'target_rocm_path' or repo variable 'RVS_TARGET_ROCM_PATH' to the absolute path of the ROCm tarball install on the target node."
             exit 1
           fi
 
@@ -205,11 +221,16 @@ jobs:
             echo "::error::Cannot parse ROCm major version from tarball name: $TARBALL_NAME"
             exit 1
           fi
-          # Install RVS into the *selected* ROCm's extras dir so it lives
-          # alongside the matching ROCm runtime; this also makes the RUNPATH-
-          # derived /opt/rocm/lib lookup harmless because LD_LIBRARY_PATH below
-          # will point at $TARGET_ROCM_PATH/lib first.
-          INSTALL_DIR="${TARGET_ROCM_PATH}/extras-${ROCM_MAJOR}"
+          # RVS is always installed into /opt/rocm/extras-<major>/ — this is
+          # decoupled from TARGET_ROCM_PATH. INSTALL_DIR is *where the RVS
+          # tarball gets extracted*; TARGET_ROCM_PATH is *where the ROCm
+          # runtime libraries live* (for LD_LIBRARY_PATH). The two concepts
+          # are intentionally separate so the install location matches the
+          # manual sequence (sudo tar -xzf ... -C /opt/rocm/extras-<major>)
+          # while the runtime lib path can be retargeted at any ROCm install
+          # on the host (e.g. a TheRock tarball under $HOME) via the repo
+          # variable RVS_TARGET_ROCM_PATH.
+          INSTALL_DIR="/opt/rocm/extras-${ROCM_MAJOR}"
           RVS_BIN_PATH="${INSTALL_DIR}/bin/rvs"
 
           # Workflow-scoped SSH state under $RUNNER_TEMP so we never touch the
@@ -286,106 +307,33 @@ jobs:
         run: |
           set -euo pipefail
           ssh -q -F "$SSH_CONFIG_FILE" rvs-target \
-            "TARBALL_NAME='$TARBALL_NAME' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
-          set -uo pipefail
-          fail=0
-
-          # rocm-smi / rocminfo are expected to already be on PATH (system
-          # package install lands them in /usr/bin; versioned installs put
-          # them under $TARGET_ROCM_PATH/bin and are typically added to PATH
-          # via /etc/profile.d). Their RPATH/RUNPATH locates ROCm runtime
-          # libs, so no LD_LIBRARY_PATH gymnastics needed here.
+            "TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
+          set -euo pipefail
 
           echo "=== System ==="
           uname -a
           echo
 
           echo "=== Target ROCm path: ${TARGET_ROCM_PATH} ==="
-          if [ -d "${TARGET_ROCM_PATH}" ]; then
-            ls -la "${TARGET_ROCM_PATH}" | head -20
-            [ -L "${TARGET_ROCM_PATH}" ] && echo "${TARGET_ROCM_PATH} -> $(readlink "${TARGET_ROCM_PATH}")"
-          else
+          if [ ! -d "${TARGET_ROCM_PATH}" ]; then
             echo "::error::${TARGET_ROCM_PATH} does not exist on the target node."
-            echo "::error::Available ROCm installs:"
-            ls -d /opt/rocm* 2>/dev/null || echo "  (none in /opt/)"
-            fail=1
-          fi
-          echo
-
-          echo "=== ROCm version (under ${TARGET_ROCM_PATH}) ==="
-          if [ -f "${TARGET_ROCM_PATH}/.info/version" ]; then
-            ROCM_VERSION=$(cat "${TARGET_ROCM_PATH}/.info/version")
-            echo "${TARGET_ROCM_PATH}/.info/version : $ROCM_VERSION"
-          elif [ -f "${TARGET_ROCM_PATH}/share/doc/rocm-core/version" ]; then
-            ROCM_VERSION=$(cat "${TARGET_ROCM_PATH}/share/doc/rocm-core/version")
-            echo "rocm-core version       : $ROCM_VERSION"
-          else
-            ROCM_VERSION=""
-            echo "::warning::no ROCm version file found under ${TARGET_ROCM_PATH}/.info/ or share/doc/rocm-core/"
-          fi
-          echo
-
-          echo "=== Major version match (tarball vs target node) ==="
-          EXPECTED_MAJOR=$(echo "$TARBALL_NAME" | grep -oE '^amdrocm[0-9]+' | grep -oE '[0-9]+' | head -1)
-          INSTALLED_MAJOR=$(echo "$ROCM_VERSION" | grep -oE '^[0-9]+' | head -1)
-          echo "tarball expects ROCm major : ${EXPECTED_MAJOR:-?}"
-          echo "target has ROCm major      : ${INSTALLED_MAJOR:-?}"
-          if [ -n "$EXPECTED_MAJOR" ] && [ -n "$INSTALLED_MAJOR" ] && [ "$EXPECTED_MAJOR" != "$INSTALLED_MAJOR" ]; then
-            echo "::error::ROCm major version mismatch (tarball=$EXPECTED_MAJOR, target=$INSTALLED_MAJOR)"
-            fail=1
-          fi
-          echo
-
-          echo "=== rocm-smi ==="
-          if command -v rocm-smi >/dev/null 2>&1; then
-            if rocm-smi --showid 2>&1 | tee /tmp/rocm-smi.out; then
-              echo "rocm-smi OK"
-            else
-              echo "::error::rocm-smi is on PATH but exited non-zero; check that the amdgpu kernel driver is loaded."
-              fail=1
-            fi
-          else
-            echo "::error::rocm-smi not found on PATH; ROCm runtime tools are missing on target."
-            fail=1
-          fi
-          echo
-
-          echo "=== rocminfo (GPU enumeration) ==="
-          if command -v rocminfo >/dev/null 2>&1; then
-            rocminfo 2>&1 | head -40 || true
-            N_GPU=$(rocminfo 2>/dev/null | grep -c 'Device Type:.*GPU' || true)
-            N_GPU=${N_GPU:-0}
-            echo "GPU agents enumerated: $N_GPU"
-            if [ "$N_GPU" -lt 1 ]; then
-              echo "::error::rocminfo enumerated 0 GPU agents; the target node does not have a usable GPU."
-              fail=1
-            fi
-          else
-            echo "::warning::rocminfo not found on PATH; skipping GPU enumeration check."
-          fi
-          echo
-
-          echo "=== Key ROCm runtime libraries (via ldconfig) ==="
-          # ldconfig -p covers both system-package installs (libs in
-          # /usr/lib/x86_64-linux-gnu) and properly-registered versioned
-          # installs (libs in /opt/rocm-*/lib with a matching ld.so.conf.d
-          # entry). For TheRock-style tarball installs that aren't
-          # registered with ldconfig, the binaries' RPATH still resolves
-          # them at runtime — so this is best-effort, warn-only.
-          for lib in libhsa-runtime64.so.1 libamdhip64.so; do
-            if ldconfig -p 2>/dev/null | grep -q "$lib"; then
-              echo "  OK    : $lib  ($(ldconfig -p 2>/dev/null | grep "$lib" | head -1 | awk -F'=> ' '{print $2}'))"
-            else
-              echo "::warning::library $lib not found in ldconfig cache (RPATH may still resolve it at runtime)"
-            fi
-          done
-          echo
-
-          if [ "$fail" -ne 0 ]; then
-            echo "::error::ROCm prerequisites check FAILED on target node — refusing to install RVS."
             exit 1
           fi
-          echo "::notice::ROCm prerequisites OK on target node at ${TARGET_ROCM_PATH}${ROCM_VERSION:+ (version $ROCM_VERSION)}"
+
+          # The TheRock tarball's bin/ binaries have RPATH/RUNPATH baked in
+          # relative to ${TARGET_ROCM_PATH}/lib, so we can invoke them
+          # directly via their absolute path without any PATH or
+          # LD_LIBRARY_PATH setup.
+
+          echo "=== ${TARGET_ROCM_PATH}/bin/rocminfo ==="
+          "${TARGET_ROCM_PATH}/bin/rocminfo"
+          echo
+
+          echo "=== ${TARGET_ROCM_PATH}/bin/amd-smi version ==="
+          "${TARGET_ROCM_PATH}/bin/amd-smi" version
+          echo
+
+          echo "::notice::ROCm prerequisites OK on target node at ${TARGET_ROCM_PATH}"
           REMOTE
 
       - name: Download tarball on runner
@@ -445,13 +393,15 @@ jobs:
             exit 1
           fi
 
-          # Hardcoded LD_LIBRARY_PATH that matches the manual workflow currently
-          # used by the RVS team. Kept literal (with /install/* paths) because
-          # the team relies on a known-working layout on the target node. If
-          # this needs to vary per ROCm install (e.g. TheRock tarball under
-          # $HOME), switch back to a $TARGET_ROCM_PATH-derived version here
-          # and in the verify/run/report steps below.
-          export LD_LIBRARY_PATH="/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:${LD_LIBRARY_PATH:-}"
+          # LD_LIBRARY_PATH is now derived from INSTALL_DIR (where RVS's own
+          # libs live) and TARGET_ROCM_PATH (where the ROCm runtime libs live).
+          # Order matches the official ROCm tarball-install docs:
+          #   $ROCM_PATH/lib/rocm_sysdeps/lib  ← TheRock-style runtime deps
+          #   $ROCM_PATH/lib/llvm/lib          ← libomp.so and friends
+          #   $ROCM_PATH/lib                   ← core ROCm libs (libamd_smi,
+          #                                      libhsa-runtime64, libamdhip64, …)
+          # Plus $INSTALL_DIR/lib first so librvslib.so resolves.
+          export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
           echo "Installed RVS at: $RVS_BIN"
           "$RVS_BIN" --version || true
           REMOTE
@@ -466,7 +416,7 @@ jobs:
             echo "::error::$RVS_BIN was not produced by tarball extraction on target."
             exit 1
           fi
-          export LD_LIBRARY_PATH="/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:${LD_LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
           echo "=== ldd $RVS_BIN ==="
           LDD_OUTPUT=$(ldd "$RVS_BIN" 2>&1 || true)
           echo "$LDD_OUTPUT"
@@ -475,55 +425,8 @@ jobs:
             echo "::error::RVS binary has unresolved library dependencies on target (see above)."
             exit 1
           fi
-
-          # Catch the "wrong ROCm leaked in" case: any /opt/rocm-<X> path in
-          # the resolved libs must match TARGET_ROCM_PATH. A bare /opt/rocm/
-          # is fine (it follows the system symlink) only when that symlink
-          # resolves to the same realpath as TARGET_ROCM_PATH.
-          TARGET_REAL=$(readlink -f "$TARGET_ROCM_PATH" 2>/dev/null || echo "$TARGET_ROCM_PATH")
-          BAD=$(echo "$LDD_OUTPUT" \
-                  | grep -oE '/opt/rocm[^ ]*' \
-                  | sort -u \
-                  | while read -r p; do
-                      preal=$(readlink -f "$p" 2>/dev/null || echo "$p")
-                      case "$preal" in
-                        "$TARGET_REAL"|"$TARGET_REAL"/*) ;;
-                        *) echo "$p -> $preal" ;;
-                      esac
-                    done)
-          if [ -n "$BAD" ]; then
-            echo "::error::RVS is resolving libraries from a ROCm install OTHER than ${TARGET_ROCM_PATH} (realpath: ${TARGET_REAL}):"
-            echo "$BAD" | sed 's/^/  /'
-            echo "::error::Set inputs.target_rocm_path / vars.RVS_TARGET_ROCM_PATH to the right versioned path, or fix the system /opt/rocm symlink."
-            exit 1
-          fi
-
-          echo "::notice::RVS binary's library dependencies resolved OK on target, all from ${TARGET_ROCM_PATH}."
+          echo "::notice::RVS binary's library dependencies resolved OK on target."
           REMOTE
-
-      - name: Run RVS level 3 on target node
-        id: rvs3
-        run: |
-          set +e
-          START=$(date -u +%FT%TZ)
-          echo "::group::RVS level 3 (${RVS_BIN} -r 3) on $TARGET_NODE against $TARGET_ROCM_PATH"
-          ssh -q -F "$SSH_CONFIG_FILE" rvs-target \
-            "RVS_BIN='$RVS_BIN' INSTALL_DIR='$INSTALL_DIR' REMOTE_WORK_DIR='$REMOTE_WORK_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
-          set +e
-          export LD_LIBRARY_PATH="/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:${LD_LIBRARY_PATH:-}"
-          mkdir -p "${REMOTE_WORK_DIR}/reports"
-          "$RVS_BIN" -r 3 2>&1 | tee "${REMOTE_WORK_DIR}/reports/rvs_level_3.log"
-          RC=${PIPESTATUS[0]}
-          echo "remote_rc=$RC"
-          exit $RC
-          REMOTE
-          RC=$?
-          echo "::endgroup::"
-          END=$(date -u +%FT%TZ)
-          echo "rc=$RC"       >> "$GITHUB_OUTPUT"
-          echo "start=$START" >> "$GITHUB_OUTPUT"
-          echo "end=$END"     >> "$GITHUB_OUTPUT"
-          exit 0
 
       - name: Run RVS level 4 on target node
         id: rvs4
@@ -534,7 +437,7 @@ jobs:
           ssh -q -F "$SSH_CONFIG_FILE" rvs-target \
             "RVS_BIN='$RVS_BIN' INSTALL_DIR='$INSTALL_DIR' REMOTE_WORK_DIR='$REMOTE_WORK_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE'
           set +e
-          export LD_LIBRARY_PATH="/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:${LD_LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
           mkdir -p "${REMOTE_WORK_DIR}/reports"
           "$RVS_BIN" -r 4 2>&1 | tee "${REMOTE_WORK_DIR}/reports/rvs_level_4.log"
           RC=${PIPESTATUS[0]}
@@ -569,11 +472,9 @@ jobs:
           set -euo pipefail
           mkdir -p ./reports
 
-          RC3=${{ steps.rvs3.outputs.rc }}
           RC4=${{ steps.rvs4.outputs.rc }}
-          [ "$RC3" -eq 0 ] && S3=PASS || S3=FAIL
           [ "$RC4" -eq 0 ] && S4=PASS || S4=FAIL
-          if [ "$RC3" -eq 0 ] && [ "$RC4" -eq 0 ]; then
+          if [ "$RC4" -eq 0 ]; then
             OVERALL=PASS
           else
             OVERALL=FAIL
@@ -584,7 +485,7 @@ jobs:
           RVS_VERSION=$(
             ssh -q -F "$SSH_CONFIG_FILE" rvs-target \
               "RVS_BIN='$RVS_BIN' INSTALL_DIR='$INSTALL_DIR' TARGET_ROCM_PATH='$TARGET_ROCM_PATH' bash -s" <<'REMOTE' 2>/dev/null | head -1 || echo "unknown"
-          export LD_LIBRARY_PATH="/opt/rocm/extras-7/lib:/install/lib:/install/lib/rocm_sysdeps/:/install/lib/llvm/lib:${LD_LIBRARY_PATH:-}"
+          export LD_LIBRARY_PATH="${INSTALL_DIR}/lib:${TARGET_ROCM_PATH}/lib/rocm_sysdeps/lib:${TARGET_ROCM_PATH}/lib/llvm/lib:${TARGET_ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"
           "$RVS_BIN" --version 2>/dev/null
           REMOTE
           )
@@ -623,15 +524,13 @@ jobs:
             echo ""
             echo "| Test | Command | Result | Exit | Started (UTC) | Ended (UTC) |"
             echo "|---|---|:--:|---:|---|---|"
-            echo "| Level 3 | \`${RVS_BIN} -r 3\` (on \`${TARGET_HOSTNAME}\`) | ${S3} | ${RC3} | ${{ steps.rvs3.outputs.start }} | ${{ steps.rvs3.outputs.end }} |"
             echo "| Level 4 | \`${RVS_BIN} -r 4\` (on \`${TARGET_HOSTNAME}\`) | ${S4} | ${RC4} | ${{ steps.rvs4.outputs.start }} | ${{ steps.rvs4.outputs.end }} |"
             echo ""
             echo "## Logs"
             echo ""
-            echo "Full per-level stdout/stderr is attached to the run artifact"
+            echo "Full stdout/stderr from the level-4 run is attached to the artifact"
             echo "\`rvs-nightly-report-${{ github.run_id }}\`:"
             echo ""
-            echo "- \`rvs_level_3.log\`"
             echo "- \`rvs_level_4.log\`"
             echo "- \`SUMMARY.md\` (this file)"
           } > "$REPORT"
@@ -641,7 +540,6 @@ jobs:
 
           {
             echo "overall=$OVERALL"
-            echo "rc3=$RC3"
             echo "rc4=$RC4"
           } >> "$GITHUB_OUTPUT"
 
@@ -670,5 +568,5 @@ jobs:
       - name: Fail the job if any level failed
         if: steps.report.outputs.overall == 'FAIL'
         run: |
-          echo "::error::RVS test failure — level3 rc=${{ steps.report.outputs.rc3 }}, level4 rc=${{ steps.report.outputs.rc4 }}"
+          echo "::error::RVS test failure — level4 rc=${{ steps.report.outputs.rc4 }}"
           exit 1


### PR DESCRIPTION

- Move RVS_TARGET_NODE and RVS_TARGET_USER from repo Variables to Secrets so they're masked as *** in run logs.
- Require RVS_TARGET_ROCM_PATH (no /opt/rocm default); decouple INSTALL_DIR (always /opt/rocm/extras-<major>) from TARGET_ROCM_PATH (drives LD_LIBRARY_PATH only); wire LD_LIBRARY_PATH dynamically off TARGET_ROCM_PATH instead of hardcoding /install/* literals.
- Simplify prereq check to <ROCM>/bin/rocminfo + <ROCM>/bin/amd-smi version; drop the cross-ROCm leak detector in verify-ldd (kept the "not found" hard fail); remove RVS level 3, keep only level 4.