### PR TITLE
enable nightly for all active branches

### DIFF
--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -16,9 +16,22 @@ All packages are built with relocatable RPATH settings, meaning they can be inst
 The workflow runs automatically on:
 - Push to `master`, `main`, or `release/**` branches
 - Pull requests to `master` or `main` branches
-- **Scheduled**: Daily at **5:00 AM PST** (13:00 UTC); **latest ROCm nightly** from [ROCm SDK nightly tarballs](https://rocm.nightlies.amd.com/tarball-multi-arch/) (or repo variable overrides).
-- **Pull requests** and **pushes** to `master`, `main`, or `release/**` (including merges): **latest ROCm release** (**X.Y.Z**) from [repo.amd.com ROCm tarballs](https://repo.amd.com/rocm/tarball/).
+- **Scheduled**: Daily at **5:00 AM PST** (13:00 UTC); **latest ROCm nightly** from [ROCm SDK nightly tarballs](https://rocm.nightlies.amd.com/tarball-multi-arch/) (or repo variable overrides). The cron fans out to the **default branch** plus every branch matched by the repository variable **`ACTIVE_BRANCHES`** (comma-separated literals/globs, e.g. `npi/**,release/**` — do not list the default branch there).
 - **Manual** (`workflow_dispatch`): if **`ROCM_VERSION`** is pinned (**workflow input** and/or **`vars.ROCM_VERSION`**), the tarball is chosen by **version format** (nightly `x.y.za…` vs release `X.Y.Z`). If no version is pinned, the job uses **latest nightly** (same as schedule).
+
+### Scheduled multi-branch nightly (`ACTIVE_BRANCHES`)
+
+| Branch source | Built on schedule? | S3 upload on schedule? | S3 path (under bucket) |
+|---------------|-------------------|------------------------|-------------------------|
+| **Default branch** (`master` / `main`) | Always | Yes | Unchanged: `nightly/rvs/deb/`, `nightly/rvs/rpm/`, `nightly/rvs/tar/` (+ APT/YUM metadata) |
+| **`ACTIVE_BRANCHES`** matches (non-default) | Yes | Yes (except `release*`) | `{branch_prefix}/{branch}/nightly/deb/`, `…/rpm/`, `…/tar/` |
+| **`release*`** matches from `ACTIVE_BRANCHES` | Yes | **No** | Packages are built and verified only |
+
+- **`branch_prefix`**: first path segment of the branch name (`npi` for `npi/foo`; for a branch with no `/`, the full branch name).
+- **`push` / `pull_request` / `workflow_dispatch`**: single-branch matrix; S3 routing is unchanged from the table below.
+- Set **`ACTIVE_BRANCHES`** under **Settings → Secrets and variables → Actions → Variables** (example: `npi/**,release/**`).
+
+- **Pull requests** and **pushes** to `master`, `main`, or `release/**` (including merges): **latest ROCm release** (**X.Y.Z**) from [repo.amd.com ROCm tarballs](https://repo.amd.com/rocm/tarball/).
 
 ### ROCm SDK: nightly vs release in CI
 
@@ -146,6 +159,7 @@ The workflow uses GitHub repository variables to control which runners execute e
 
 | Variable | Default | Used by |
 |----------|---------|---------|
+| `ACTIVE_BRANCHES` | _(unset)_ | **Scheduled** nightly only: comma-separated branch literals/globs (`npi/**`, `release/**`). Default branch is always built; do not list it here. `release*` matches build but do not upload on schedule. |
 | `RUNNER_LABEL` | `ubuntu-22.04` | Ubuntu build job |
 | `RUNNER_LABEL_CONTAINER` | `ubuntu-latest` | CentOS/manylinux build job (container) |
 | `RUNNER_LABEL_UTILITY` | `ubuntu-latest` | Release summary job |
@@ -169,7 +183,10 @@ To use a self-hosted runner, set the variable to your runner's label (e.g., `sel
 | Trigger | Path | Contents |
 |--------|------|----------|
 | **`release/*` branch** (`push` or `workflow_dispatch`) | `release/rvs/deb/`, `release/rvs/rpm/`, `release/rvs/tar/` | DEB → `.../deb` (Ubuntu job); RPM and TGZ → `.../rpm` and `.../tar` (manylinux job). Only PR merges into release branches or manual dispatch on release branches write here. |
-| **Scheduled**, **push to `master`/`main`**, or **`workflow_dispatch` on non-release branch** | `nightly/rvs/deb/`, `nightly/rvs/rpm/`, `nightly/rvs/tar/` | Same split by type. All non-release builds go to nightly. |
+| **Scheduled** (default branch only) | `nightly/rvs/deb/`, `nightly/rvs/rpm/`, `nightly/rvs/tar/` | Same as before; APT/YUM metadata generated here. |
+| **Scheduled** (`ACTIVE_BRANCHES`, non-default, not `release*`) | `{branch_prefix}/{branch}/nightly/deb/`, `…/rpm/`, `…/tar/` | No shared `rvs/` segment; no repo metadata on these paths. |
+| **Scheduled** (`release*` from `ACTIVE_BRANCHES`) | _(none)_ | Build only; upload skipped. |
+| **Push to `master`/`main`**, or **`workflow_dispatch` on non-release branch** | `nightly/rvs/deb/`, `nightly/rvs/rpm/`, `nightly/rvs/tar/` | Same split by type. |
 | **Pull request** (same-repo) | `rvs/<ref_name>/<run_number>/ubuntu-22.04/` or `.../manylinux_2_28/` | DEB only (Ubuntu job); RPM+TGZ (manylinux job). One-off path, no repo metadata generated. |
 
 If `AWS_S3_BUCKET` is not set, the upload step is skipped with a warning (the workflow still succeeds).

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -47,14 +47,124 @@ env:
   RVS_AUTO_DETECT_LOCAL_UPLOAD: ${{ vars.RVS_AUTO_DETECT_LOCAL_UPLOAD }}
 
 jobs:
+  prepare-nightly-branches:
+    name: Prepare nightly branch matrix
+    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    outputs:
+      branches_json: ${{ steps.branches.outputs.branches_json }}
+    steps:
+      - name: Checkout (for remote branch list)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve branch matrix
+        id: branches
+        env:
+          ACTIVE_BRANCHES: ${{ vars.ACTIVE_BRANCHES }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+
+          def branch_prefix(name: str) -> str:
+              return name.split("/", 1)[0] if "/" in name else name
+
+          def glob_match(name: str, pattern: str) -> bool:
+              regex_parts = []
+              i = 0
+              while i < len(pattern):
+                  if pattern[i : i + 2] == "**":
+                      regex_parts.append(".*")
+                      i += 2
+                  elif pattern[i] == "*":
+                      regex_parts.append("[^/]*")
+                      i += 1
+                  else:
+                      regex_parts.append(re.escape(pattern[i]))
+                      i += 1
+              return re.fullmatch("".join(regex_parts), name) is not None
+
+          def skip_upload_schedule(branch: str) -> bool:
+              return branch == "release" or branch.startswith("release/")
+
+          event = os.environ["EVENT_NAME"]
+          default = os.environ["DEFAULT_BRANCH"]
+
+          if event != "schedule":
+              if event == "pull_request":
+                  branch = os.environ.get("PR_HEAD_REF") or os.environ["REF_NAME"]
+              else:
+                  branch = os.environ["REF_NAME"]
+              branches = [{
+                  "branch": branch,
+                  "is_default": branch == default,
+                  "skip_upload": False,
+                  "branch_prefix": branch_prefix(branch),
+              }]
+          else:
+              patterns = [
+                  p.strip()
+                  for p in os.environ.get("ACTIVE_BRANCHES", "").split(",")
+                  if p.strip()
+              ]
+              subprocess.run(["git", "fetch", "origin", "--prune"], check=True)
+              result = subprocess.run(
+                  ["git", "branch", "-r"],
+                  capture_output=True,
+                  text=True,
+                  check=True,
+              )
+              remote_names = []
+              for line in result.stdout.splitlines():
+                  line = line.strip()
+                  if not line or "->" in line:
+                      continue
+                  if line.startswith("origin/"):
+                      remote_names.append(line[len("origin/"):])
+
+              matched = set()
+              for pattern in patterns:
+                  for name in remote_names:
+                      if glob_match(name, pattern) and name != default:
+                          matched.add(name)
+
+              branches = [{
+                  "branch": default,
+                  "is_default": True,
+                  "skip_upload": False,
+                  "branch_prefix": branch_prefix(default),
+              }]
+              for name in sorted(matched):
+                  branches.append({
+                      "branch": name,
+                      "is_default": False,
+                      "skip_upload": skip_upload_schedule(name),
+                      "branch_prefix": branch_prefix(name),
+                  })
+
+          payload = json.dumps(branches)
+          print(payload)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"branches_json={payload}\n")
+          PY
+
   build-ubuntu:
-    name: Build Ubuntu Packages
+    name: Build Ubuntu Packages (${{ matrix.branch }})
+    needs: prepare-nightly-branches
     runs-on: ${{ vars.RUNNER_LABEL || 'ubuntu-22.04' }}
     container:
-      image: ubuntu:${{ matrix.ubuntu_version }}
+      image: ubuntu:22.04
     strategy:
+      fail-fast: false
       matrix:
-        ubuntu_version: ['22.04']
+        include: ${{ fromJson(needs.prepare-nightly-branches.outputs.branches_json) }}
     # Apply to every step in the job so apt never drops into an interactive
     # frontend (tzdata, libssl, etc.) — each Actions step runs in a fresh
     # shell, so an `export` inside one step does not propagate to the next.
@@ -84,8 +194,16 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
           fetch-depth: 0
+
+      - name: Set build branch context
+        run: |
+          echo "RVS_BUILD_REF_NAME=${{ matrix.branch }}" >> "$GITHUB_ENV"
+          echo "RVS_IS_DEFAULT_BRANCH=${{ matrix.is_default }}" >> "$GITHUB_ENV"
+          echo "RVS_SKIP_UPLOAD=${{ matrix.skip_upload }}" >> "$GITHUB_ENV"
+          echo "RVS_BRANCH_PREFIX=${{ matrix.branch_prefix }}" >> "$GITHUB_ENV"
 
       - name: Set ROCm Version and GPU Family
         run: |
@@ -198,11 +316,11 @@ jobs:
 
       # S3 upload for ROCm/ROCmValidationSuite only (skip fork PRs: OIDC token response is empty → JSON parse fails)
       - name: Install AWS CLI
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: apt-get update && apt-get install -y awscli
 
       - name: Configure AWS credentials
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | python3 -c "import sys,json; print(json.load(sys.stdin)['value'])")
@@ -220,10 +338,10 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
 
-      # S3 routing: release/* (push/manual) → release/; schedule/push/manual → nightly/; else → ref-specific
+      # S3 routing: schedule non-default → {prefix}/{branch}/nightly/; schedule default → nightly/rvs/; release/* push/manual → release/
       - name: Upload Ubuntu packages to S3
         id: upload-s3-ubuntu
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           if [ -z "$BUCKET" ]; then
@@ -231,7 +349,19 @@ jobs:
             exit 0
           fi
           BASE="rvs"
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]] && { [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; }; then
+          if [ "${RVS_SKIP_UPLOAD}" = "true" ]; then
+            echo "Skipping S3 upload (scheduled release* branch)."
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "${RVS_IS_DEFAULT_BRANCH}" != "true" ]; then
+            S3_PREFIX="${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly"
+            echo "Scheduled ACTIVE_BRANCHES build: uploading to ${S3_PREFIX}/deb"
+            aws s3 cp ./build "s3://${BUCKET}/${S3_PREFIX}/deb/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
+            echo "Listing s3://${BUCKET}/${S3_PREFIX}/deb/"
+            aws s3 ls "s3://${BUCKET}/${S3_PREFIX}/deb/" --human-readable || true
+            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
+            echo "paths=Ubuntu DEB|${S3_PREFIX}/deb" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/heads/release/* ]] && { [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; }; then
             echo "Release branch build: uploading to release/rvs/deb"
             aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/deb/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
             echo "Listing s3://${BUCKET}/release/${BASE}/deb/"
@@ -246,7 +376,7 @@ jobs:
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=Ubuntu DEB|nightly/${BASE}/deb" >> $GITHUB_OUTPUT
           else
-            PREFIX="${BASE}/${{ github.ref_name }}/${{ github.run_number }}/ubuntu-${{ matrix.ubuntu_version }}"
+            PREFIX="${BASE}/${{ github.ref_name }}/${{ github.run_number }}/ubuntu-22.04"
             echo "Uploading to s3://${BUCKET}/${PREFIX}/"
             aws s3 cp ./build "s3://${BUCKET}/${PREFIX}/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
             echo "Listing s3://${BUCKET}/${PREFIX}/"
@@ -260,7 +390,7 @@ jobs:
       # can be consumed directly as a DEB repository by apt.
       # Only runs when the repository is ROCm/ROCmValidationSuite and the event is schedule, push, or manual.
       - name: Generate and upload DEB repo metadata to S3
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && matrix.skip_upload != true && (github.event_name != 'schedule' || matrix.is_default == true)
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           [ -z "$BUCKET" ] && exit 0
@@ -304,13 +434,15 @@ jobs:
           aws s3 ls "s3://${BUCKET}/${DEB_PREFIX}/" --human-readable || true
 
   build-centos:
-    name: Build CentOS/RHEL Packages (manylinux_2_28)
+    name: Build CentOS/RHEL Packages (${{ matrix.branch }})
+    needs: prepare-nightly-branches
     runs-on: ${{ vars.RUNNER_LABEL_CONTAINER || 'ubuntu-latest' }}
     container:
       image: quay.io/pypa/manylinux_2_28_x86_64
     strategy:
+      fail-fast: false
       matrix:
-        distro: ['manylinux_2_28']
+        include: ${{ fromJson(needs.prepare-nightly-branches.outputs.branches_json) }}
     outputs:
       s3_bucket_centos: ${{ steps.upload-s3-centos.outputs.bucket }}
       s3_paths_centos: ${{ steps.upload-s3-centos.outputs.paths }}
@@ -323,8 +455,16 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ matrix.branch }}
           submodules: recursive
           fetch-depth: 0
+
+      - name: Set build branch context
+        run: |
+          echo "RVS_BUILD_REF_NAME=${{ matrix.branch }}" >> "$GITHUB_ENV"
+          echo "RVS_IS_DEFAULT_BRANCH=${{ matrix.is_default }}" >> "$GITHUB_ENV"
+          echo "RVS_SKIP_UPLOAD=${{ matrix.skip_upload }}" >> "$GITHUB_ENV"
+          echo "RVS_BRANCH_PREFIX=${{ matrix.branch_prefix }}" >> "$GITHUB_ENV"
 
       - name: Set ROCm Version and GPU Family
         run: |
@@ -437,12 +577,12 @@ jobs:
 
       # S3 upload for ROCm/ROCmValidationSuite only (skip fork PRs — OIDC not usable)
       - name: Install AWS CLI
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           python3 -m pip install --break-system-packages awscli || (yum install -y python3-pip && pip3 install awscli)
 
       - name: Configure AWS credentials
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
             "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=sts.amazonaws.com" | python3 -c "import sys,json; print(json.load(sys.stdin)['value'])")
@@ -460,10 +600,10 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
 
-      # S3 routing: release/* (push/manual) → release/; schedule/push/manual → nightly/; else → ref-specific
+      # S3 routing: schedule non-default → {prefix}/{branch}/nightly/; schedule default → nightly/rvs/; release/* push/manual → release/
       - name: Upload CentOS/RHEL packages to S3
         id: upload-s3-centos
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           if [ -z "$BUCKET" ]; then
@@ -471,7 +611,22 @@ jobs:
             exit 0
           fi
           BASE="rvs"
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]] && { [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; }; then
+          if [ "${RVS_SKIP_UPLOAD}" = "true" ]; then
+            echo "Skipping S3 upload (scheduled release* branch)."
+            exit 0
+          fi
+          if [ "${{ github.event_name }}" = "schedule" ] && [ "${RVS_IS_DEFAULT_BRANCH}" != "true" ]; then
+            S3_PREFIX="${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly"
+            echo "Scheduled ACTIVE_BRANCHES build: uploading to ${S3_PREFIX}/rpm and ${S3_PREFIX}/tar"
+            aws s3 cp ./build "s3://${BUCKET}/${S3_PREFIX}/rpm/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
+            aws s3 cp ./build "s3://${BUCKET}/${S3_PREFIX}/tar/" --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
+            echo "Listing s3://${BUCKET}/${S3_PREFIX}/rpm/"
+            aws s3 ls "s3://${BUCKET}/${S3_PREFIX}/rpm/" --human-readable || true
+            echo "Listing s3://${BUCKET}/${S3_PREFIX}/tar/"
+            aws s3 ls "s3://${BUCKET}/${S3_PREFIX}/tar/" --human-readable || true
+            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
+            echo "paths=CentOS/RHEL RPM|${S3_PREFIX}/rpm||CentOS/RHEL TGZ|${S3_PREFIX}/tar" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.ref }}" == refs/heads/release/* ]] && { [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; }; then
             echo "Release branch build: uploading to release/rvs/rpm and release/rvs/tar"
             aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/rpm/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
             aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/tar/" --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
@@ -492,7 +647,7 @@ jobs:
             echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
             echo "paths=CentOS/RHEL RPM|nightly/${BASE}/rpm||CentOS/RHEL TGZ|nightly/${BASE}/tar" >> $GITHUB_OUTPUT
           else
-            PREFIX="${BASE}/${{ github.ref_name }}/${{ github.run_number }}/${{ matrix.distro }}"
+            PREFIX="${BASE}/${{ github.ref_name }}/${{ github.run_number }}/manylinux_2_28"
             echo "Uploading to s3://${BUCKET}/${PREFIX}/"
             aws s3 cp ./build "s3://${BUCKET}/${PREFIX}/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --include "amdrocm*-rvs*.tar.gz" --no-progress
             echo "Listing s3://${BUCKET}/${PREFIX}/"
@@ -506,7 +661,7 @@ jobs:
       # directly as an RPM repository by yum/dnf.
       # Only runs when the repository is ROCm/ROCmValidationSuite and the event is schedule, push, or manual.
       - name: Generate and upload RPM repodata to S3
-        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && (github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && matrix.skip_upload != true && (github.event_name != 'schedule' || matrix.is_default == true)
         run: |
           BUCKET="${{ vars.AWS_S3_BUCKET }}"
           [ -z "$BUCKET" ] && exit 0
@@ -539,8 +694,8 @@ jobs:
     name: Create Release Summary
     needs: [build-ubuntu, build-centos]
     runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
-    # Only runs when the workflow is not cancelled and always() is true
-    if: always() && !cancelled()
+    # Skip on schedule: matrix builds do not aggregate job outputs reliably
+    if: always() && !cancelled() && github.event_name != 'schedule'
 
     steps:
       - name: Generate Build Report


### PR DESCRIPTION

## Motivation

By enabling nightly build for all branch is to make sure build is working with latest ROCm for all supported branches. Particularly for release branches build need to continue and working till end of support for a particular release series.

## Test Plan

Test by enabling active release branches.

## Test Result

NA

## Submission Checklist

