### PR TITLE
fix typerror on local runner with older python

### DIFF
--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -70,10 +70,10 @@ jobs:
           import re
           import urllib.request
 
-          def list_remote_branches() -> list[str]:
+          def list_remote_branches():
               token = os.environ["GITHUB_TOKEN"]
               repo = os.environ["GITHUB_REPOSITORY"]
-              names: list[str] = []
+              names = []
               page = 1
               while True:
                   url = (


### PR DESCRIPTION
## Motivation

Fix typeerror with local runner running on python-3.8

## Technical Details

TypeError: 'type' object is not subscriptable on line 6 of the inline script is from list[str] annotations. That syntax needs Python 3.9+. Removing Python 3.9+ type hints (list[str]) the self-hosted runner uses Python 3.8.

## Test Plan

Functional active branch nightly running on local runner.
## Test Result

NA


