### PR TITLE
S3 upload and ROCm download stream fix

### DIFF
--- a/.github/scripts/configure-rocm-sdk-channel.sh
+++ b/.github/scripts/configure-rocm-sdk-channel.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Configure ROCm SDK channel + ROCM_VERSION for build_packages_local.sh (CI).
+# Uses POSIX case for release/* refs (safe under dash/sh and bash).
+set -euo pipefail
+
+GITHUB_ENV="${GITHUB_ENV:-/dev/null}"
+
+NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-}"
+NIGHTLY_IDX="${ROCM_SDK_NIGHTLY_INDEX_URL:-}"
+[ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
+[ -z "$NIGHTLY_IDX" ] && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
+
+REL_URL="${ROCM_SDK_RELEASE_URL:-}"
+[ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
+REL_BASE="${ROCM_SDK_RELEASE_BASE_URL:-}"
+[ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
+
+EVENT="${GITHUB_EVENT_NAME:-}"
+REF="${GITHUB_REF:-}"
+IN_VER="${INPUT_ROCM_VERSION:-}"
+VAR_VER="${VAR_ROCM_VERSION:-}"
+IN_GPU="${INPUT_GPU_FAMILY:-}"
+
+release_build() {
+  {
+    echo "ROCM_SDK_CHANNEL=release"
+    echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+    echo "ROCM_SDK_BASE_URL=$REL_BASE"
+    echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+    echo "ROCM_SDK_INDEX_URL="
+  } >> "$GITHUB_ENV"
+}
+
+nightly_build() {
+  {
+    echo "ROCM_SDK_CHANNEL=nightly"
+    echo "ROCM_SDK_RELEASE_URL="
+    echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+    echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+  } >> "$GITHUB_ENV"
+}
+
+format_build() {
+  {
+    echo "ROCM_SDK_CHANNEL=auto"
+    echo "ROCM_SDK_RELEASE_URL=$REL_URL"
+    echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
+    echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
+    echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
+    echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
+    echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
+  } >> "$GITHUB_ENV"
+}
+
+# ROCM_VERSION: schedule clears; dispatch input; push/PR use repo variable when set.
+if [ "$EVENT" = "schedule" ]; then
+  echo "ROCM_VERSION=" >> "$GITHUB_ENV"
+  echo "Scheduled run: build script will auto-fetch latest ROCm version"
+elif [ -n "$IN_VER" ]; then
+  echo "ROCM_VERSION=$IN_VER" >> "$GITHUB_ENV"
+  echo "Using workflow_dispatch ROCm version: $IN_VER"
+elif [ -n "$VAR_VER" ]; then
+  echo "ROCM_VERSION=$VAR_VER" >> "$GITHUB_ENV"
+  echo "Using repository variable ROCM_VERSION: $VAR_VER"
+fi
+
+if [ -n "$IN_GPU" ]; then
+  echo "GPU_FAMILY=$IN_GPU" >> "$GITHUB_ENV"
+fi
+
+if [ "$EVENT" = "schedule" ]; then
+  nightly_build
+  echo "ROCm SDK channel: nightly (scheduled — latest nightly)"
+elif [ "$EVENT" = "pull_request" ]; then
+  release_build
+  echo "ROCm SDK channel: release (pull request — latest X.Y.Z)"
+elif [ "$EVENT" = "push" ]; then
+  case "$REF" in
+    refs/heads/master|refs/heads/main|refs/heads/release/*)
+      release_build
+      echo "ROCm SDK channel: release (push to main or release/* — includes merge)"
+      ;;
+    *)
+      nightly_build
+      echo "ROCm SDK channel: nightly (push to feature branch)"
+      ;;
+  esac
+elif [ "$EVENT" = "workflow_dispatch" ]; then
+  if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
+    format_build
+    echo "ROCm SDK: manual — tarball base chosen by version format (input or vars.ROCM_VERSION)"
+  else
+    nightly_build
+    echo "ROCm SDK channel: nightly (manual, no version pin)"
+  fi
+else
+  nightly_build
+  echo "ROCm SDK channel: nightly (fallback)"
+fi

--- a/.github/scripts/rvs-s3-upload-route.sh
+++ b/.github/scripts/rvs-s3-upload-route.sh
@@ -1,0 +1,170 @@
+#!/bin/sh
+# POSIX S3 path routing for RVS packages (ubuntu:22.04 container uses sh/dash).
+# Usage:
+#   rvs-s3-upload-route.sh upload-deb
+#   rvs-s3-upload-route.sh upload-rpm-tar
+#   rvs-s3-upload-route.sh deb-repo-prefix
+#   rvs-s3-upload-route.sh rpm-repo-prefix
+set -eu
+
+BASE="rvs"
+EVENT="${GITHUB_EVENT_NAME:-}"
+REF="${GITHUB_REF:-}"
+REF_NAME="${GITHUB_REF_NAME:-}"
+RUN_NUMBER="${GITHUB_RUN_NUMBER:-0}"
+BUCKET="${AWS_S3_BUCKET:-}"
+GITHUB_OUTPUT="${GITHUB_OUTPUT:-/dev/null}"
+
+RVS_SKIP_UPLOAD="${RVS_SKIP_UPLOAD:-false}"
+RVS_IS_DEFAULT_BRANCH="${RVS_IS_DEFAULT_BRANCH:-false}"
+RVS_BRANCH_PREFIX="${RVS_BRANCH_PREFIX:-}"
+RVS_BUILD_REF_NAME="${RVS_BUILD_REF_NAME:-}"
+RUNNER_SUFFIX="${RVS_RUNNER_SUFFIX:-ubuntu-22.04}"
+
+rvs_is_release_ref() {
+  case "$1" in
+    refs/heads/release/*) return 0 ;;
+  esac
+  return 1
+}
+
+rvs_resolve_route() {
+  RVS_S3_ROUTE="pr"
+  RVS_S3_DEB_PREFIX=""
+  RVS_S3_RPM_PREFIX=""
+  RVS_S3_TAR_PREFIX=""
+  RVS_APT_SUITE="rvs-nightly"
+  RVS_S3_OUTPUT_PATHS=""
+
+  if [ "$RVS_SKIP_UPLOAD" = "true" ]; then
+    RVS_S3_ROUTE="skip"
+    return 0
+  fi
+
+  if [ "$EVENT" = "schedule" ] && [ "$RVS_IS_DEFAULT_BRANCH" != "true" ]; then
+    RVS_S3_ROUTE="scheduled_branch"
+    RVS_S3_DEB_PREFIX="${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly/deb"
+    RVS_S3_RPM_PREFIX="${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly/rpm"
+    RVS_S3_TAR_PREFIX="${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly/tar"
+    RVS_S3_OUTPUT_PATHS="Ubuntu DEB|${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly/deb||CentOS/RHEL RPM|${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly/rpm||CentOS/RHEL TGZ|${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly/tar"
+    return 0
+  fi
+
+  if rvs_is_release_ref "$REF" && { [ "$EVENT" = "push" ] || [ "$EVENT" = "workflow_dispatch" ]; }; then
+    RVS_S3_ROUTE="release"
+    RVS_S3_DEB_PREFIX="release/${BASE}/deb"
+    RVS_S3_RPM_PREFIX="release/${BASE}/rpm"
+    RVS_S3_TAR_PREFIX="release/${BASE}/tar"
+    RVS_APT_SUITE="rvs-release"
+    RVS_S3_OUTPUT_PATHS="Ubuntu DEB|release/${BASE}/deb||CentOS/RHEL RPM|release/${BASE}/rpm||CentOS/RHEL TGZ|release/${BASE}/tar"
+    return 0
+  fi
+
+  if [ "$EVENT" = "schedule" ] || [ "$EVENT" = "push" ] || [ "$EVENT" = "workflow_dispatch" ]; then
+    RVS_S3_ROUTE="nightly"
+    RVS_S3_DEB_PREFIX="nightly/${BASE}/deb"
+    RVS_S3_RPM_PREFIX="nightly/${BASE}/rpm"
+    RVS_S3_TAR_PREFIX="nightly/${BASE}/tar"
+    RVS_APT_SUITE="rvs-nightly"
+    RVS_S3_OUTPUT_PATHS="Ubuntu DEB|nightly/${BASE}/deb||CentOS/RHEL RPM|nightly/${BASE}/rpm||CentOS/RHEL TGZ|nightly/${BASE}/tar"
+    return 0
+  fi
+
+  RVS_S3_ROUTE="pr"
+  RVS_S3_DEB_PREFIX="${BASE}/${REF_NAME}/${RUN_NUMBER}/${RUNNER_SUFFIX}"
+  RVS_S3_RPM_PREFIX="${BASE}/${REF_NAME}/${RUN_NUMBER}/manylinux_2_28"
+  RVS_S3_TAR_PREFIX="${RVS_S3_RPM_PREFIX}"
+  RVS_S3_OUTPUT_PATHS="Ubuntu DEB|${RVS_S3_DEB_PREFIX}||CentOS/RHEL packages|${RVS_S3_RPM_PREFIX}"
+}
+
+cmd="${1:-}"
+rvs_resolve_route
+
+case "$cmd" in
+  upload-deb)
+    if [ -z "$BUCKET" ]; then
+      echo "::warning::AWS_S3_BUCKET not set. Skipping S3 upload."
+      exit 0
+    fi
+    if [ "$RVS_S3_ROUTE" = "skip" ]; then
+      echo "Skipping S3 upload (scheduled release* branch)."
+      exit 0
+    fi
+    case "$RVS_S3_ROUTE" in
+      scheduled_branch)
+        echo "Scheduled ACTIVE_BRANCHES build: uploading to ${RVS_S3_DEB_PREFIX}"
+        ;;
+      release)
+        echo "Release branch build: uploading to ${RVS_S3_DEB_PREFIX}"
+        ;;
+      nightly)
+        echo "Nightly/push build: uploading to ${RVS_S3_DEB_PREFIX}"
+        ;;
+      *)
+        echo "Uploading to s3://${BUCKET}/${RVS_S3_DEB_PREFIX}/"
+        ;;
+    esac
+    aws s3 cp ./build "s3://${BUCKET}/${RVS_S3_DEB_PREFIX}/" \
+      --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
+    echo "Listing s3://${BUCKET}/${RVS_S3_DEB_PREFIX}/"
+    aws s3 ls "s3://${BUCKET}/${RVS_S3_DEB_PREFIX}/" --human-readable || true
+    echo "bucket=${BUCKET}" >> "$GITHUB_OUTPUT"
+    echo "paths=Ubuntu DEB|${RVS_S3_DEB_PREFIX}" >> "$GITHUB_OUTPUT"
+    echo "Done."
+    ;;
+  upload-rpm-tar)
+    if [ -z "$BUCKET" ]; then
+      echo "::warning::AWS_S3_BUCKET not set. Skipping S3 upload."
+      exit 0
+    fi
+    if [ "$RVS_S3_ROUTE" = "skip" ]; then
+      echo "Skipping S3 upload (scheduled release* branch)."
+      exit 0
+    fi
+    case "$RVS_S3_ROUTE" in
+      scheduled_branch)
+        echo "Scheduled ACTIVE_BRANCHES build: uploading to ${RVS_S3_RPM_PREFIX} and ${RVS_S3_TAR_PREFIX}"
+        ;;
+      release)
+        echo "Release branch build: uploading to ${RVS_S3_RPM_PREFIX} and ${RVS_S3_TAR_PREFIX}"
+        ;;
+      nightly)
+        echo "Nightly/push build: uploading to ${RVS_S3_RPM_PREFIX} and ${RVS_S3_TAR_PREFIX}"
+        ;;
+      *)
+        echo "Uploading to s3://${BUCKET}/${RVS_S3_RPM_PREFIX}/"
+        ;;
+    esac
+    if [ "$RVS_S3_ROUTE" = "pr" ]; then
+      aws s3 cp ./build "s3://${BUCKET}/${RVS_S3_RPM_PREFIX}/" \
+        --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --include "amdrocm*-rvs*.tar.gz" --no-progress
+      echo "Listing s3://${BUCKET}/${RVS_S3_RPM_PREFIX}/"
+      aws s3 ls "s3://${BUCKET}/${RVS_S3_RPM_PREFIX}/" --human-readable || true
+      echo "bucket=${BUCKET}" >> "$GITHUB_OUTPUT"
+      echo "paths=CentOS/RHEL packages|${RVS_S3_RPM_PREFIX}" >> "$GITHUB_OUTPUT"
+    else
+      aws s3 cp ./build "s3://${BUCKET}/${RVS_S3_RPM_PREFIX}/" \
+        --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
+      aws s3 cp ./build "s3://${BUCKET}/${RVS_S3_TAR_PREFIX}/" \
+        --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
+      echo "Listing s3://${BUCKET}/${RVS_S3_RPM_PREFIX}/"
+      aws s3 ls "s3://${BUCKET}/${RVS_S3_RPM_PREFIX}/" --human-readable || true
+      echo "Listing s3://${BUCKET}/${RVS_S3_TAR_PREFIX}/"
+      aws s3 ls "s3://${BUCKET}/${RVS_S3_TAR_PREFIX}/" --human-readable || true
+      echo "bucket=${BUCKET}" >> "$GITHUB_OUTPUT"
+      echo "paths=CentOS/RHEL RPM|${RVS_S3_RPM_PREFIX}||CentOS/RHEL TGZ|${RVS_S3_TAR_PREFIX}" >> "$GITHUB_OUTPUT"
+    fi
+    echo "Done."
+    ;;
+  deb-repo-prefix)
+    echo "$RVS_S3_DEB_PREFIX"
+    echo "$RVS_APT_SUITE"
+    ;;
+  rpm-repo-prefix)
+    echo "$RVS_S3_RPM_PREFIX"
+    ;;
+  *)
+    echo "Usage: $0 upload-deb|upload-rpm-tar|deb-repo-prefix|rpm-repo-prefix" >&2
+    exit 1
+    ;;
+esac

--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -35,7 +35,9 @@ The workflow runs automatically on:
 
 ### ROCm SDK: nightly vs release in CI
 
-The workflow sets `ROCM_SDK_CHANNEL` and SDK URLs before calling `build_packages_local.sh`:
+The workflow runs [`.github/scripts/configure-rocm-sdk-channel.sh`](../scripts/configure-rocm-sdk-channel.sh) to set `ROCM_SDK_CHANNEL`, SDK URLs, and `ROCM_VERSION` (from `vars.ROCM_VERSION` on push/PR, or `workflow_dispatch` input) before calling `build_packages_local.sh`. Release-branch detection uses POSIX `case` (not bash `[[`), so it works in the Ubuntu `ubuntu:22.04` container where steps may run under `sh`.
+
+**ROCm pin vs S3 layout:** A nightly SDK pin (e.g. `7.14.0a20260528`) only affects **which tarball is downloaded**. **`workflow_dispatch` or `push` on a `release/**` branch** still uploads packages to **`release/rvs/`** (see S3 table below).
 
 | Trigger | SDK source |
 |---------|------------|
@@ -178,7 +180,7 @@ To use a self-hosted runner, set the variable to your runner's label (e.g., `sel
 
 3. **AWS IAM**: The role in `AWS_ROLE_ARN` must have a trust policy allowing GitHub OIDC to assume it (identity provider `token.actions.githubusercontent.com`, audience `sts.amazonaws.com`) and permissions to `s3:PutObject` (and related) on the bucket.
 
-**S3 path layout:**
+**S3 path layout** (resolved by [`.github/scripts/rvs-s3-upload-route.sh`](../scripts/rvs-s3-upload-route.sh), POSIX-safe for Ubuntu `sh`):
 
 | Trigger | Path | Contents |
 |--------|------|----------|

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -223,94 +223,17 @@ jobs:
           echo "RVS_SKIP_UPLOAD=${{ matrix.skip_upload }}" >> "$GITHUB_ENV"
           echo "RVS_BRANCH_PREFIX=${{ matrix.branch_prefix }}" >> "$GITHUB_ENV"
 
-      - name: Set ROCm Version and GPU Family
-        run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "ROCM_VERSION=" >> $GITHUB_ENV
-            echo "Scheduled run: build script will auto-fetch latest ROCm version"
-          elif [ -n "${{ github.event.inputs.rocm_version }}" ]; then
-            echo "ROCM_VERSION=${{ github.event.inputs.rocm_version }}" >> $GITHUB_ENV
-          fi
-          if [ -n "${{ github.event.inputs.gpu_family }}" ]; then
-            echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
-          fi
-
-      # Schedule → latest ROCm *nightly*. PR + merge (push to main/master/release/*) → latest ROCm *release*.
-      # Manual: if a version is pinned (workflow input or vars.ROCM_VERSION), tarball follows *format* (auto).
-      - name: Configure ROCm SDK channel (nightly vs release)
-        run: |
-          NIGHTLY_BASE='${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}'
-          NIGHTLY_IDX='${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}'
-          [ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
-          [ -z "$NIGHTLY_IDX" ] && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
-
-          REL_URL='${{ vars.ROCM_SDK_RELEASE_URL }}'
-          [ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
-          REL_BASE='${{ vars.ROCM_SDK_RELEASE_BASE_URL }}'
-          [ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
-
-          release_build() {
-            {
-              echo "ROCM_SDK_CHANNEL=release"
-              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
-              echo "ROCM_SDK_BASE_URL=$REL_BASE"
-              echo "ROCM_SDK_INDEX_URL="
-            } >> "$GITHUB_ENV"
-          }
-
-          nightly_build() {
-            {
-              echo "ROCM_SDK_CHANNEL=nightly"
-              echo "ROCM_SDK_RELEASE_URL="
-              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
-              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
-            } >> "$GITHUB_ENV"
-          }
-
-          # Manual run with a pin: resolve tarball location by version format (nightly x.y.za… vs release X.Y.Z)
-          format_build() {
-            {
-              echo "ROCM_SDK_CHANNEL=auto"
-              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
-              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
-              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
-              echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
-              echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
-              echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
-            } >> "$GITHUB_ENV"
-          }
-
-          EVENT='${{ github.event_name }}'
-          REF='${{ github.ref }}'
-          IN_VER='${{ github.event.inputs.rocm_version }}'
-          VAR_VER='${{ vars.ROCM_VERSION }}'
-
-          if [ "$EVENT" = "schedule" ]; then
-            nightly_build
-            echo "ROCm SDK channel: nightly (scheduled — latest nightly)"
-          elif [ "$EVENT" = "pull_request" ]; then
-            release_build
-            echo "ROCm SDK channel: release (pull request — latest X.Y.Z)"
-          elif [ "$EVENT" = "push" ]; then
-            if [ "$REF" = "refs/heads/master" ] || [ "$REF" = "refs/heads/main" ] || [[ "$REF" == refs/heads/release/* ]]; then
-              release_build
-              echo "ROCm SDK channel: release (push to main or release/* — includes merge)"
-            else
-              nightly_build
-              echo "ROCm SDK channel: nightly (push to feature branch)"
-            fi
-          elif [ "$EVENT" = "workflow_dispatch" ]; then
-            if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
-              format_build
-              echo "ROCm SDK: manual — tarball base chosen by version format (input or vars.ROCM_VERSION)"
-            else
-              nightly_build
-              echo "ROCm SDK channel: nightly (manual, no version pin)"
-            fi
-          else
-            nightly_build
-            echo "ROCm SDK channel: nightly (fallback)"
-          fi
+      # Schedule → nightly SDK. PR/push main|release/* → release SDK. Manual pin → format (auto).
+      - name: Configure ROCm SDK channel and version
+        run: bash .github/scripts/configure-rocm-sdk-channel.sh
+        env:
+          INPUT_ROCM_VERSION: ${{ github.event.inputs.rocm_version }}
+          VAR_ROCM_VERSION: ${{ vars.ROCM_VERSION }}
+          INPUT_GPU_FAMILY: ${{ github.event.inputs.gpu_family }}
+          ROCM_SDK_RELEASE_URL: ${{ vars.ROCM_SDK_RELEASE_URL }}
+          ROCM_SDK_RELEASE_BASE_URL: ${{ vars.ROCM_SDK_RELEASE_BASE_URL }}
+          ROCM_SDK_NIGHTLY_BASE_URL: ${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}
+          ROCM_SDK_NIGHTLY_INDEX_URL: ${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}
 
       # Forward LOCAL_PACKAGE_SERVER_URL to the build script as UPLOAD_TARGET.
       - name: Configure local package upload
@@ -381,53 +304,14 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
 
-      # S3 routing: schedule non-default → {prefix}/{branch}/nightly/; schedule default → nightly/rvs/; release/* push/manual → release/
+      # S3 routing: POSIX script (ubuntu:22.04 container uses sh — no bash [[).
       - name: Upload Ubuntu packages to S3
         id: upload-s3-ubuntu
         if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
-        run: |
-          BUCKET="${{ vars.AWS_S3_BUCKET }}"
-          if [ -z "$BUCKET" ]; then
-            echo "::warning::AWS_S3_BUCKET not set. Skipping S3 upload."
-            exit 0
-          fi
-          BASE="rvs"
-          if [ "${RVS_SKIP_UPLOAD}" = "true" ]; then
-            echo "Skipping S3 upload (scheduled release* branch)."
-            exit 0
-          fi
-          if [ "${{ github.event_name }}" = "schedule" ] && [ "${RVS_IS_DEFAULT_BRANCH}" != "true" ]; then
-            S3_PREFIX="${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly"
-            echo "Scheduled ACTIVE_BRANCHES build: uploading to ${S3_PREFIX}/deb"
-            aws s3 cp ./build "s3://${BUCKET}/${S3_PREFIX}/deb/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
-            echo "Listing s3://${BUCKET}/${S3_PREFIX}/deb/"
-            aws s3 ls "s3://${BUCKET}/${S3_PREFIX}/deb/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=Ubuntu DEB|${S3_PREFIX}/deb" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == refs/heads/release/* ]] && { [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; }; then
-            echo "Release branch build: uploading to release/rvs/deb"
-            aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/deb/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
-            echo "Listing s3://${BUCKET}/release/${BASE}/deb/"
-            aws s3 ls "s3://${BUCKET}/release/${BASE}/deb/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=Ubuntu DEB|release/${BASE}/deb" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Nightly/push build: uploading to nightly/rvs/deb"
-            aws s3 cp ./build "s3://${BUCKET}/nightly/${BASE}/deb/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
-            echo "Listing s3://${BUCKET}/nightly/${BASE}/deb/"
-            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/deb/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=Ubuntu DEB|nightly/${BASE}/deb" >> $GITHUB_OUTPUT
-          else
-            PREFIX="${BASE}/${{ github.ref_name }}/${{ github.run_number }}/ubuntu-22.04"
-            echo "Uploading to s3://${BUCKET}/${PREFIX}/"
-            aws s3 cp ./build "s3://${BUCKET}/${PREFIX}/" --recursive --exclude "*" --include "amdrocm*-rvs*.deb" --no-progress
-            echo "Listing s3://${BUCKET}/${PREFIX}/"
-            aws s3 ls "s3://${BUCKET}/${PREFIX}/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=Ubuntu DEB|${PREFIX}" >> $GITHUB_OUTPUT
-          fi
-          echo "Done."
+        run: sh .github/scripts/rvs-s3-upload-route.sh upload-deb
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+          RVS_RUNNER_SUFFIX: ubuntu-22.04
 
       # Generate APT repo metadata (Packages, Packages.gz, Release) so the S3 path
       # can be consumed directly as a DEB repository by apt.
@@ -439,15 +323,9 @@ jobs:
           [ -z "$BUCKET" ] && exit 0
 
           # dpkg-dev and apt-utils were installed in the Bootstrap container step.
-
-          BASE="rvs"
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
-            DEB_PREFIX="release/${BASE}/deb"
-            APT_SUITE="rvs-release"
-          else
-            DEB_PREFIX="nightly/${BASE}/deb"
-            APT_SUITE="rvs-nightly"
-          fi
+          set -- $(sh .github/scripts/rvs-s3-upload-route.sh deb-repo-prefix)
+          DEB_PREFIX="$1"
+          APT_SUITE="$2"
 
           STAGING=$(mktemp -d)
 
@@ -475,6 +353,9 @@ jobs:
 
           echo "=== DEB repo metadata uploaded to s3://${BUCKET}/${DEB_PREFIX}/ ==="
           aws s3 ls "s3://${BUCKET}/${DEB_PREFIX}/" --human-readable || true
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+          RVS_RUNNER_SUFFIX: ubuntu-22.04
 
   build-centos:
     name: Build CentOS/RHEL Packages (${{ matrix.branch }})
@@ -511,92 +392,16 @@ jobs:
           echo "RVS_SKIP_UPLOAD=${{ matrix.skip_upload }}" >> "$GITHUB_ENV"
           echo "RVS_BRANCH_PREFIX=${{ matrix.branch_prefix }}" >> "$GITHUB_ENV"
 
-      - name: Set ROCm Version and GPU Family
-        run: |
-          if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "ROCM_VERSION=" >> $GITHUB_ENV
-            echo "Scheduled run: build script will auto-fetch latest ROCm version"
-          elif [ -n "${{ github.event.inputs.rocm_version }}" ]; then
-            echo "ROCM_VERSION=${{ github.event.inputs.rocm_version }}" >> $GITHUB_ENV
-          fi
-          if [ -n "${{ github.event.inputs.gpu_family }}" ]; then
-            echo "GPU_FAMILY=${{ github.event.inputs.gpu_family }}" >> $GITHUB_ENV
-          fi
-
-      # Schedule → nightly latest. PR + merge → release latest. Manual → format when version pinned.
-      - name: Configure ROCm SDK channel (nightly vs release)
-        run: |
-          NIGHTLY_BASE='${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}'
-          NIGHTLY_IDX='${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}'
-          [ -z "$NIGHTLY_BASE" ] && NIGHTLY_BASE='https://rocm.nightlies.amd.com/tarball-multi-arch'
-          [ -z "$NIGHTLY_IDX" ] && NIGHTLY_IDX='https://rocm.nightlies.amd.com/tarball-multi-arch/'
-
-          REL_URL='${{ vars.ROCM_SDK_RELEASE_URL }}'
-          [ -z "$REL_URL" ] && REL_URL='https://repo.amd.com/rocm/tarball/'
-          REL_BASE='${{ vars.ROCM_SDK_RELEASE_BASE_URL }}'
-          [ -z "$REL_BASE" ] && REL_BASE="${REL_URL%/}"
-
-          release_build() {
-            {
-              echo "ROCM_SDK_CHANNEL=release"
-              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
-              echo "ROCM_SDK_BASE_URL=$REL_BASE"
-              echo "ROCM_SDK_INDEX_URL="
-            } >> "$GITHUB_ENV"
-          }
-
-          nightly_build() {
-            {
-              echo "ROCM_SDK_CHANNEL=nightly"
-              echo "ROCM_SDK_RELEASE_URL="
-              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
-              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
-            } >> "$GITHUB_ENV"
-          }
-
-          format_build() {
-            {
-              echo "ROCM_SDK_CHANNEL=auto"
-              echo "ROCM_SDK_RELEASE_URL=$REL_URL"
-              echo "ROCM_SDK_INDEX_URL=$NIGHTLY_IDX"
-              echo "ROCM_SDK_BASE_URL=$NIGHTLY_BASE"
-              echo "ROCM_SDK_NIGHTLY_BASE_URL=$NIGHTLY_BASE"
-              echo "ROCM_SDK_NIGHTLY_INDEX_URL=$NIGHTLY_IDX"
-              echo "ROCM_SDK_RELEASE_BASE_URL=$REL_BASE"
-            } >> "$GITHUB_ENV"
-          }
-
-          EVENT='${{ github.event_name }}'
-          REF='${{ github.ref }}'
-          IN_VER='${{ github.event.inputs.rocm_version }}'
-          VAR_VER='${{ vars.ROCM_VERSION }}'
-
-          if [ "$EVENT" = "schedule" ]; then
-            nightly_build
-            echo "ROCm SDK channel: nightly (scheduled)"
-          elif [ "$EVENT" = "pull_request" ]; then
-            release_build
-            echo "ROCm SDK channel: release (pull request)"
-          elif [ "$EVENT" = "push" ]; then
-            if [ "$REF" = "refs/heads/master" ] || [ "$REF" = "refs/heads/main" ] || [[ "$REF" == refs/heads/release/* ]]; then
-              release_build
-              echo "ROCm SDK channel: release (push to main or release/*)"
-            else
-              nightly_build
-              echo "ROCm SDK channel: nightly (feature branch push)"
-            fi
-          elif [ "$EVENT" = "workflow_dispatch" ]; then
-            if [ -n "$IN_VER" ] || [ -n "$VAR_VER" ]; then
-              format_build
-              echo "ROCm SDK: manual — format-based tarball"
-            else
-              nightly_build
-              echo "ROCm SDK channel: nightly (manual, no version)"
-            fi
-          else
-            nightly_build
-            echo "ROCm SDK channel: nightly (fallback)"
-          fi
+      - name: Configure ROCm SDK channel and version
+        run: bash .github/scripts/configure-rocm-sdk-channel.sh
+        env:
+          INPUT_ROCM_VERSION: ${{ github.event.inputs.rocm_version }}
+          VAR_ROCM_VERSION: ${{ vars.ROCM_VERSION }}
+          INPUT_GPU_FAMILY: ${{ github.event.inputs.gpu_family }}
+          ROCM_SDK_RELEASE_URL: ${{ vars.ROCM_SDK_RELEASE_URL }}
+          ROCM_SDK_RELEASE_BASE_URL: ${{ vars.ROCM_SDK_RELEASE_BASE_URL }}
+          ROCM_SDK_NIGHTLY_BASE_URL: ${{ vars.ROCM_SDK_NIGHTLY_BASE_URL }}
+          ROCM_SDK_NIGHTLY_INDEX_URL: ${{ vars.ROCM_SDK_NIGHTLY_INDEX_URL }}
 
       - name: Configure local package upload
         if: vars.LOCAL_PACKAGE_SERVER_URL != ''
@@ -668,62 +473,13 @@ jobs:
         env:
           AWS_DEFAULT_REGION: us-east-1
 
-      # S3 routing: schedule non-default → {prefix}/{branch}/nightly/; schedule default → nightly/rvs/; release/* push/manual → release/
       - name: Upload CentOS/RHEL packages to S3
         id: upload-s3-centos
         if: github.repository == 'ROCm/ROCmValidationSuite' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && matrix.skip_upload != true
-        run: |
-          BUCKET="${{ vars.AWS_S3_BUCKET }}"
-          if [ -z "$BUCKET" ]; then
-            echo "::warning::AWS_S3_BUCKET not set. Skipping S3 upload."
-            exit 0
-          fi
-          BASE="rvs"
-          if [ "${RVS_SKIP_UPLOAD}" = "true" ]; then
-            echo "Skipping S3 upload (scheduled release* branch)."
-            exit 0
-          fi
-          if [ "${{ github.event_name }}" = "schedule" ] && [ "${RVS_IS_DEFAULT_BRANCH}" != "true" ]; then
-            S3_PREFIX="${RVS_BRANCH_PREFIX}/${RVS_BUILD_REF_NAME}/nightly"
-            echo "Scheduled ACTIVE_BRANCHES build: uploading to ${S3_PREFIX}/rpm and ${S3_PREFIX}/tar"
-            aws s3 cp ./build "s3://${BUCKET}/${S3_PREFIX}/rpm/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
-            aws s3 cp ./build "s3://${BUCKET}/${S3_PREFIX}/tar/" --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
-            echo "Listing s3://${BUCKET}/${S3_PREFIX}/rpm/"
-            aws s3 ls "s3://${BUCKET}/${S3_PREFIX}/rpm/" --human-readable || true
-            echo "Listing s3://${BUCKET}/${S3_PREFIX}/tar/"
-            aws s3 ls "s3://${BUCKET}/${S3_PREFIX}/tar/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=CentOS/RHEL RPM|${S3_PREFIX}/rpm||CentOS/RHEL TGZ|${S3_PREFIX}/tar" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.ref }}" == refs/heads/release/* ]] && { [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; }; then
-            echo "Release branch build: uploading to release/rvs/rpm and release/rvs/tar"
-            aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/rpm/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
-            aws s3 cp ./build "s3://${BUCKET}/release/${BASE}/tar/" --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
-            echo "Listing s3://${BUCKET}/release/${BASE}/rpm/"
-            aws s3 ls "s3://${BUCKET}/release/${BASE}/rpm/" --human-readable || true
-            echo "Listing s3://${BUCKET}/release/${BASE}/tar/"
-            aws s3 ls "s3://${BUCKET}/release/${BASE}/tar/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=CentOS/RHEL RPM|release/${BASE}/rpm||CentOS/RHEL TGZ|release/${BASE}/tar" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "Nightly/push build: uploading to nightly/rvs/rpm and nightly/rvs/tar"
-            aws s3 cp ./build "s3://${BUCKET}/nightly/${BASE}/rpm/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --no-progress
-            aws s3 cp ./build "s3://${BUCKET}/nightly/${BASE}/tar/" --recursive --exclude "*" --include "amdrocm*-rvs*.tar.gz" --no-progress
-            echo "Listing s3://${BUCKET}/nightly/${BASE}/rpm/"
-            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/rpm/" --human-readable || true
-            echo "Listing s3://${BUCKET}/nightly/${BASE}/tar/"
-            aws s3 ls "s3://${BUCKET}/nightly/${BASE}/tar/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=CentOS/RHEL RPM|nightly/${BASE}/rpm||CentOS/RHEL TGZ|nightly/${BASE}/tar" >> $GITHUB_OUTPUT
-          else
-            PREFIX="${BASE}/${{ github.ref_name }}/${{ github.run_number }}/manylinux_2_28"
-            echo "Uploading to s3://${BUCKET}/${PREFIX}/"
-            aws s3 cp ./build "s3://${BUCKET}/${PREFIX}/" --recursive --exclude "*" --include "amdrocm*-rvs*.rpm" --include "amdrocm*-rvs*.tar.gz" --no-progress
-            echo "Listing s3://${BUCKET}/${PREFIX}/"
-            aws s3 ls "s3://${BUCKET}/${PREFIX}/" --human-readable || true
-            echo "bucket=${BUCKET}" >> $GITHUB_OUTPUT
-            echo "paths=CentOS/RHEL packages|${PREFIX}" >> $GITHUB_OUTPUT
-          fi
-          echo "Done."
+        run: sh .github/scripts/rvs-s3-upload-route.sh upload-rpm-tar
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+          RVS_RUNNER_SUFFIX: manylinux_2_28
 
       # Generate YUM/DNF repo metadata (repodata/) so the S3 path can be consumed
       # directly as an RPM repository by yum/dnf.
@@ -736,12 +492,7 @@ jobs:
 
           yum install -y createrepo_c || yum install -y createrepo
 
-          BASE="rvs"
-          if [[ "${{ github.ref }}" == refs/heads/release/* ]]; then
-            RPM_PREFIX="release/${BASE}/rpm"
-          else
-            RPM_PREFIX="nightly/${BASE}/rpm"
-          fi
+          RPM_PREFIX=$(sh .github/scripts/rvs-s3-upload-route.sh rpm-repo-prefix)
 
           STAGING=$(mktemp -d)
 
@@ -757,6 +508,9 @@ jobs:
 
           echo "=== RPM repodata uploaded to s3://${BUCKET}/${RPM_PREFIX}/repodata/ ==="
           aws s3 ls "s3://${BUCKET}/${RPM_PREFIX}/repodata/" --human-readable || true
+        env:
+          AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
+          RVS_RUNNER_SUFFIX: manylinux_2_28
 
   create-release:
     name: Create Release Summary


### PR DESCRIPTION
## Motivation

With recent addition to workflow release pipeline is not detecting ROCm download link correctly with ROCm version set as x.y.z in Ubuntu Job(RHEL no issues). Similarly for upload to S3 it gets pushed to nightly folder instead of release folder.

## Technical Details


Root cause of the issue is with the way script is run differently on Ubuntu/manylinux env.
Solving by adding dedicated scripts for download and upload stream selection and run using sh to ensure identical behavior on both.

