### PR TITLE
fix the null to null string

### DIFF
--- a/rvs/conf/MI350X/pebb_single.conf
+++ b/rvs/conf/MI350X/pebb_single.conf
@@ -98,7 +98,7 @@ actions:
   warm_calls: 3
   hot_calls: 10
   source_memory: cpu
-  destination_memory: null
+  destination_memory: "null"
 
 # Device-to-Host/GPU-to-CPU bandwidth test using TransferBench via GFX
 - name: pcie_d2h_bandwidth_tb_gfx
@@ -115,6 +115,6 @@ actions:
   subexecutor: 8
   warm_calls: 3
   hot_calls: 10
-  source_memory: null
+  source_memory: "null"
   destination_memory: cpu
  

--- a/rvs/conf/MI355X/pebb_single.conf
+++ b/rvs/conf/MI355X/pebb_single.conf
@@ -98,7 +98,7 @@ actions:
   warm_calls: 3
   hot_calls: 10
   source_memory: cpu
-  destination_memory: null
+  destination_memory: "null"
 
 # Device-to-Host/GPU-to-CPU bandwidth test using TransferBench via GFX
 - name: pcie_d2h_bandwidth_tb_gfx
@@ -115,6 +115,6 @@ actions:
   subexecutor: 8
   warm_calls: 3
   hot_calls: 10
-  source_memory: null
+  source_memory: "null"
   destination_memory: cpu
  


### PR DESCRIPTION
In yaml, unquoted null is treated as a special null node and when rvs tries to parse this , it cannot convert from null node to string node, so we get type mismatch error. QUalifying it as "null" will ensure our intention