### PR TITLE
Ensuring right folder for non-master uploads

### DIFF
--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -252,8 +252,8 @@ jobs:
         if: vars.LOCAL_PACKAGE_SERVER_URL != ''
         run: |
           REPO="${GITHUB_REPOSITORY##*/}"
-          BRANCH="${GITHUB_REF_NAME}"
-          SAFE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g')
+          BRANCH="${RVS_BUILD_REF_NAME:-$GITHUB_REF_NAME}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._/-]|-|g')
           DATE=$(date +%Y-%m-%d)
           URL="${{ vars.LOCAL_PACKAGE_SERVER_URL }}/${REPO}/${SAFE_BRANCH}/${DATE}/"
           echo "================================================================"
@@ -417,8 +417,8 @@ jobs:
         if: vars.LOCAL_PACKAGE_SERVER_URL != ''
         run: |
           REPO="${GITHUB_REPOSITORY##*/}"
-          BRANCH="${GITHUB_REF_NAME}"
-          SAFE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g')
+          BRANCH="${RVS_BUILD_REF_NAME:-$GITHUB_REF_NAME}"
+          SAFE_BRANCH=$(echo "$BRANCH" | sed 's|[^a-zA-Z0-9._/-]|-|g')
           DATE=$(date +%Y-%m-%d)
           URL="${{ vars.LOCAL_PACKAGE_SERVER_URL }}/${REPO}/${SAFE_BRANCH}/${DATE}/"
           echo "================================================================"

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -641,7 +641,7 @@ BASE_PACKAGE_RELEASE="r${ROCM_LIBPATCH_VERSION}.${RELEASE_DATE}"
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && [ -n "${GITHUB_HEAD_REF:-}" ]; then
     GIT_BRANCH="${GITHUB_HEAD_REF}"
 else
-    GIT_BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")}"
+    GIT_BRANCH="${RVS_BUILD_REF_NAME:-${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")}}"
 fi
 if [ -n "$GITHUB_SHA" ]; then
     GIT_COMMIT_SHORT="${GITHUB_SHA:0:7}"
@@ -895,8 +895,8 @@ if [ -n "$UPLOAD_TARGET" ]; then
         [ -z "$UPLOAD_REPO" ] && UPLOAD_REPO=$(basename "$(git rev-parse --show-toplevel 2>/dev/null)" 2>/dev/null)
         [ -z "$UPLOAD_REPO" ] && UPLOAD_REPO="unknown"
     fi
-    UPLOAD_BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")}"
-    UPLOAD_BRANCH=$(echo "$UPLOAD_BRANCH" | sed 's|[^a-zA-Z0-9._-]|-|g')
+    UPLOAD_BRANCH="${RVS_BUILD_REF_NAME:-${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")}}"
+    UPLOAD_BRANCH=$(echo "$UPLOAD_BRANCH" | sed 's|[^a-zA-Z0-9._/-]|-|g')
     UPLOAD_DATE=$(date +%Y-%m-%d)
     UPLOAD_SUBPATH="${UPLOAD_REPO}/${UPLOAD_BRANCH}/${UPLOAD_DATE}"
 


### PR DESCRIPTION
Local uploads were posting to "master" folder even when run from other branches due to usage of GITHUB_REF_NAME instead of actual RVS_BUILD_REF_NAME variable which points to branch. This PR fixes the same and keeps / in name, as is the case with s3 uploads.

Uploads now remain consistent and uses branch names for folders and fall back is the master in case RVS_BUILD_REF_NAME isnt set.
