### PR TITLE
changed the target node to orchestrator for downloading tarball

### DIFF
--- a/.github/workflows/README_NIGHTLY_TESTS.md
+++ b/.github/workflows/README_NIGHTLY_TESTS.md
@@ -16,17 +16,12 @@ at any GPU host without code changes.
 schedule / workflow_run / manual
     │
     ▼
-detect-tarball              [utility runner]
-    │  curl <index URL> → pick newest amdrocm*-rvs-*.tar.gz (index = secret or workflow default)
+install-rvs-on-target       [self-hosted orchestrator]  ──ssh──▶  [target GPU node]
+    │  resolve index + validate paths (orchestrator only)
+    │  setup-ssh → download .tar.gz on runner (curl never on target) → scp to target
+    │  verify-rocm → install-rvs → verify-rvs-binary (commands run on target via ssh)
     ▼
-prepare-test-context        [utility runner]
-    │  rvs_nightly_test.sh validate-config → paths + remote work dir
-    ▼
-install-rvs-on-target       [test runner]  ──ssh──▶  [target GPU node]
-    │  rvs_nightly_test.sh: setup-ssh, verify-rocm, download, copy,
-    │                         install-rvs, verify-rvs-binary
-    ▼
-run-rvs-level-4             [test runner]  ──ssh──▶  [target GPU node]
+run-rvs-level-4             [self-hosted orchestrator]  ──ssh──▶  [target GPU node]
     │  rvs_nightly_test.sh: run-level4, collect-logs, capture-versions
     │  upload intermediate logs artifact; cleanup remote work dir
     ▼
@@ -93,9 +88,10 @@ gh workflow run rvs-nightly-tests.yml \
 
 | Name | Required? | Purpose |
 |---|---|---|
+| `RVS_NIGHTLY_INDEX_RUNNER_LABEL` | optional (defaults to `RVS_TEST_RUNNER_LABEL`) | Runner label for **install-rvs-on-target** (resolve + download + scp). Use a self-hosted pool with HTTPS egress to the tarball index and `.tar.gz` host. The GPU target never performs those downloads. If unset, `RVS_TEST_RUNNER_LABEL` (then `self-hosted`) is used. |
 | `RVS_REMOTE_WORK_DIR` | optional (default `/tmp/rvs-nightly-<run_id>`) | Working dir on the target node. Cleared with `rm -rf` at the end of the job. |
 | `RVS_TARGET_ROCM_PATH` | **Required** *(unless every run sets `target_rocm_path` input)* | Absolute path to the ROCm tarball install root on the target node — the directory that contains `bin/rocminfo`, `bin/amd-smi`, `lib/`, `lib/llvm/lib/`, and `lib/rocm_sysdeps/lib/`. The workflow doesn't assume any conventional path (no `/opt/rocm` default), since tarball installs land wherever you extracted them. |
-| `RVS_TEST_RUNNER_LABEL` | optional (default `self-hosted`) | Label of the GitHub runner that orchestrates the workflow. The runner doesn't need a GPU or ROCm — it just needs `ssh`, `scp`, and `curl`. |
+| `RVS_TEST_RUNNER_LABEL` | optional (default `self-hosted`) | Label for **run-rvs-level-4**. **install-rvs-on-target** uses `RVS_NIGHTLY_INDEX_RUNNER_LABEL` when set, otherwise this label — that job resolves the index, **downloads the tarball on the orchestrator**, and `scp`s it to the target (the target never curls the CDN). Requires `ssh`, `scp`, `curl`, and HTTPS egress to the tarball hosts. Does not need a GPU or ROCm. |
 
 **Secrets** (Settings → Secrets and variables → Actions → Secrets):
 
@@ -108,7 +104,7 @@ gh workflow run rvs-nightly-tests.yml \
 
 ## How the latest tarball is picked
 
-The `detect` job does (with `$INDEX_URL` = `secrets.RVS_TARBALL_INDEX_URL` if set, else the default from the workflow `env.TARBALL_INDEX_URL` expression):
+The **Resolve latest tarball URL** step at the start of **install-rvs-on-target** runs on the orchestrator (with `$INDEX_URL` = `secrets.RVS_TARBALL_INDEX_URL` if set, else the default from the workflow `env.TARBALL_INDEX_URL` expression):
 
 ```bash
 curl -sL "$INDEX_URL" \
@@ -133,7 +129,7 @@ directory under the chosen ROCm. The same workflow handles ROCm 6, 7,
 etc., and any version inside `7.x` without code changes:
 
 ```bash
-# On the runner (Validate target node configuration step):
+# On the orchestrator (Validate configuration step in install-rvs-on-target):
 # Parsed from $TARBALL_NAME via [[ "$TARBALL_NAME" =~ ^amdrocm([0-9]+)- ]]
 ROCM_MAJOR=7
 # INSTALL_DIR is always /opt/rocm/extras-<major>/ — it's where the RVS
@@ -263,9 +259,10 @@ if `$RVS_BIN` isn't executable after extraction.
 **On the GitHub runner (orchestrator):**
 
 - `ssh`, `scp`, `ssh-keyscan`, and `curl` on `PATH`.
-- Network egress to:
-  - the host serving the tarball index URL (typically HTTPS port 443; either `secrets.RVS_TARBALL_INDEX_URL` or the workflow’s built-in default),
-  - the target node (port 22 — or wherever its sshd listens, configurable in the SSH config block of the workflow).
+- **install-rvs-on-target** runs on `vars.RVS_NIGHTLY_INDEX_RUNNER_LABEL` or `vars.RVS_TEST_RUNNER_LABEL` (see Variables). On that runner only: `curl` resolves the latest tarball from the index, `curl` downloads the `.tar.gz` to `./pkg/`, then `scp` pushes it to the target. The GPU target never curls the index or CDN.
+- Network egress from that orchestrator to:
+  - the tarball index and tarball file hosts (HTTPS port 443; from `secrets.RVS_TARBALL_INDEX_URL` / workflow default unless `workflow_dispatch.tarball_url` is set),
+  - the target node (SSH, typically port 22).
 - The runner does **not** need a GPU, ROCm, or `sudo`.
 
 **On the target node** (all enforced by the **Pre-flight ROCm checks** below — the workflow fails fast if any are missing):
@@ -277,7 +274,7 @@ if `$RVS_BIN` isn't executable after extraction.
 
 ## Pre-flight ROCm checks
 
-Before downloading or installing the tarball, the workflow runs **`Verify ROCm prerequisites on target node`** over SSH. It's deliberately minimal — two probes against the actual install at `$TARGET_ROCM_PATH`:
+Before extracting the RVS tarball on the target, the workflow runs **`Verify ROCm prerequisites on target node`** over SSH. It's deliberately minimal — two probes against the actual install at `$TARGET_ROCM_PATH`:
 
 | Sub-check | Action on failure | Catches |
 |---|---|---|
@@ -406,12 +403,14 @@ we do not duplicate host identity in our own script output.
 
 ## GitHub runner vs target node
 
-The `test` job runs on `${{ vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}`,
-but this runner only orchestrates — it doesn't need a GPU or ROCm. You can:
+The **install-rvs-on-target** and **run-rvs-level-4** jobs use
+`${{ vars.RVS_NIGHTLY_INDEX_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}`
+and `${{ vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}` respectively so **index resolution, tarball download, and `scp`**
+happen only on the orchestrator. The runner only orchestrates — it doesn't need a GPU or ROCm. You can:
 
-- Reuse an existing self-hosted runner that already has SSH access to the lab.
-- Use a small purpose-built orchestration runner (any Linux box with `ssh`/`scp`/`curl`).
-- In principle, use a GitHub-hosted `ubuntu-latest` runner — but that requires the target node to be reachable from GitHub's hosted runner IPs, which usually isn't the case for lab hosts behind a VPN/bastion.
+- Reuse an existing self-hosted runner that already has SSH access to the lab **and** HTTPS egress to the tarball hosts.
+- Use a small purpose-built orchestration runner (any Linux box with `ssh`/`scp`/`curl` and outbound HTTPS).
+- **GitHub-hosted `ubuntu-latest`** is not used for tarball resolution or download; those steps must run where lab egress allows.
 
 The **target node** is what needs the GPU, ROCm, and `NOPASSWD` sudo. It does **not** need to be a registered GitHub runner.
 
@@ -431,22 +430,23 @@ gh workflow run rvs-nightly-tests.yml
 
 Watch the Actions tab for:
 
-1. `detect` resolves a tarball URL (`Latest tarball : amdrocm<N>-rvs-…`).
-2. `test` job picks up on your orchestrator runner.
-3. **Validate target node configuration** prints `Target ROCm path`, `Remote work dir`, and `Expected RVS binary` (SSH target host/user are **not** printed).
-4. **Setup SSH key for target node** verifies SSH connectivity (no host identity printed to logs).
+1. **install-rvs-on-target** resolves a tarball URL (`Latest tarball : amdrocm<N>-rvs-…`) on the orchestrator only.
+2. **Validate configuration** (same job) prints `Target ROCm path`, `Remote work dir`, and `Expected RVS binary` (SSH target host/user are **not** printed).
+3. **Setup SSH for target node** verifies SSH connectivity (no host identity printed to logs).
+4. **Download tarball on orchestrator** then **Copy tarball to target** — the `.tar.gz` is never fetched on the GPU node.
 5. **Verify ROCm prerequisites on target node** prints `::notice::ROCm prerequisites OK on target node at <TARGET_ROCM_PATH>`.
 6. **Install RVS on target node** prints the detected `ROCM_MAJOR`, the chosen `Target ROCm path`, and `Installed RVS at: <TARGET_ROCM_PATH>/extras-<N>/bin/rvs`.
 7. **Verify RVS binary library resolution on target node** prints `::notice::RVS binary's library dependencies resolved OK on target, all from <TARGET_ROCM_PATH>`.
-8. RVS level 4 step completes; the run summary shows the results table with the Level 4 row and overall PASS/FAIL.
+8. **run-rvs-level-4** completes; the run summary shows the results table with the Level 4 row and overall PASS/FAIL.
 
 ## Debugging a failed run
 
 | Symptom | Likely cause |
 |---|---|
-| `detect` job exits with "No tarball index URL…" (should not occur) | Report as a workflow bug; the YAML supplies a default index when the secret is unset. |
-| `detect` job exits with "Could not resolve a tarball URL" | The index page returned no matches. Confirm network access to the index host, inspect the HTML listing for `amdrocm*-rvs-*-Linux.tar.gz` links, and/or set secret `RVS_TARBALL_INDEX_URL` to a valid listing URL. Compare with the fallback string in `env.TARBALL_INDEX_URL` in [`rvs-nightly-tests.yml`](./rvs-nightly-tests.yml) if you rely on the built-in default. |
-| `test` job stuck "Queued" | No orchestrator runner online with the label in `vars.RVS_TEST_RUNNER_LABEL`. |
+| **install-rvs-on-target** exits with "No tarball index URL…" (should not occur) | Report as a workflow bug; the YAML supplies a default index when the secret is unset. |
+| **Resolve latest tarball URL** fails with "Could not resolve a tarball URL" | The index page returned no matches. Confirm network access from the orchestrator to the index host, inspect the HTML listing for `amdrocm*-rvs-*-Linux.tar.gz` links, and/or set secret `RVS_TARBALL_INDEX_URL` to a valid listing URL. Compare with the fallback string in `env.TARBALL_INDEX_URL` in [`rvs-nightly-tests.yml`](./rvs-nightly-tests.yml) if you rely on the built-in default. |
+| **install-rvs-on-target** stuck "Queued" | No runner online for `vars.RVS_NIGHTLY_INDEX_RUNNER_LABEL` or `vars.RVS_TEST_RUNNER_LABEL` (see Actions → Runners). That job performs index `curl`, tarball download, and `scp` to the target. |
+| **run-rvs-level-4** stuck "Queued" | No orchestrator runner online with the label in `vars.RVS_TEST_RUNNER_LABEL`. |
 | **Validate target node configuration** fails: `No target node configured` | Neither `inputs.target_node` nor `secrets.RVS_TARGET_NODE` is set. Add the secret in Settings → Secrets and variables → Actions → Secrets, or pass `target_node` via `workflow_dispatch`. |
 | **Setup SSH key for target node** fails: `secrets.RVS_TARGET_SSH_KEY is not set` | The required secret is missing. Add the private SSH key as a repo secret. |
 | **Setup SSH key for target node** fails: `Permission denied (publickey)` | The key in `RVS_TARGET_SSH_KEY` isn't authorized on the target node for `$TARGET_USER`, or the key format is wrong. Verify from a workstation with `ssh -i <keyfile> -o BatchMode=yes <user>@<host> true` (use your real user, host, and key; exit code 0 means the key works). |

--- a/.github/workflows/rvs-nightly-tests.yml
+++ b/.github/workflows/rvs-nightly-tests.yml
@@ -10,7 +10,10 @@ name: RVS Nightly Tests
 # build_packages_local.sh).
 #
 # Required repo configuration: see README_NIGHTLY_TESTS.md
-
+#
+# Tarball index resolution, tarball download, and scp to the GPU target all run on
+# the self-hosted orchestrator job below — the target never curls the index or CDN.
+#
 # Triggers
 # --------
 # - schedule: daily poll of tarball index (repo secret or workflow fallback URL)
@@ -59,14 +62,26 @@ env:
   TARBALL_INDEX_URL: ${{ secrets.RVS_TARBALL_INDEX_URL || 'https://d22tya8uodfbu6.cloudfront.net/nightly/rvs/tar/' }}
 
 jobs:
-  detect-tarball:
-    name: Detect latest RVS tarball
+  install-rvs-on-target:
+    name: Install RVS on target node
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    runs-on: ${{ vars.RVS_NIGHTLY_INDEX_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
+    timeout-minutes: 120
     outputs:
-      tarball_url:  ${{ steps.resolve.outputs.tarball_url }}
-      tarball_name: ${{ steps.resolve.outputs.tarball_name }}
+      tarball_url:      ${{ steps.resolve.outputs.tarball_url }}
+      tarball_name:     ${{ steps.resolve.outputs.tarball_name }}
+      remote_work_dir:  ${{ steps.prepare.outputs.remote_work_dir }}
+      rocm_major:       ${{ steps.prepare.outputs.rocm_major }}
+      install_dir:      ${{ steps.prepare.outputs.install_dir }}
+      rvs_bin:          ${{ steps.prepare.outputs.rvs_bin }}
+    env:
+      TARGET_NODE:      ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
+      TARGET_USER:      ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
+      TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RVS_TARGET_ROCM_PATH }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
       - name: Restore last-seen marker (cron path)
         if: github.event_name == 'schedule'
         uses: actions/cache@v4
@@ -76,7 +91,7 @@ jobs:
           restore-keys: |
             rvs-nightly-tarball-
 
-      - name: Resolve latest tarball URL
+      - name: Resolve latest tarball URL (orchestrator only)
         id: resolve
         env:
           INDEX_URL: ${{ env.TARBALL_INDEX_URL }}
@@ -129,35 +144,26 @@ jobs:
             echo "tarball_name=$NAME"
           } >> "$GITHUB_OUTPUT"
 
+          # Later steps in this job read TARBALL_URL / TARBALL_NAME (download-tarball, etc.)
+          {
+            echo "TARBALL_URL=$URL"
+            echo "TARBALL_NAME=$NAME"
+          } >> "$GITHUB_ENV"
+
           echo "Latest tarball : $NAME"
           echo "URL            : $URL"
 
-      - name: Save marker (cron path)
+      - name: Save last-seen marker (cron path)
         if: github.event_name == 'schedule'
         uses: actions/cache/save@v4
         with:
           path: last_tarball_marker.txt
           key: rvs-nightly-tarball-${{ steps.resolve.outputs.tarball_name }}
 
-  prepare-test-context:
-    name: Prepare test run context
-    needs: detect-tarball
-    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
-    outputs:
-      remote_work_dir:  ${{ steps.prepare.outputs.remote_work_dir }}
-      rocm_major:       ${{ steps.prepare.outputs.rocm_major }}
-      install_dir:      ${{ steps.prepare.outputs.install_dir }}
-      rvs_bin:          ${{ steps.prepare.outputs.rvs_bin }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
       - name: Validate configuration and derive paths
         id: prepare
         env:
-          TARBALL_NAME: ${{ needs.detect-tarball.outputs.tarball_name }}
-          TARGET_NODE:  ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
-          TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RVS_TARGET_ROCM_PATH }}
+          TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
           INPUT_REMOTE_WORK_DIR: ${{ inputs.remote_work_dir }}
           VAR_REMOTE_WORK_DIR:   ${{ vars.RVS_REMOTE_WORK_DIR }}
           GITHUB_RUN_ID: ${{ github.run_id }}
@@ -165,24 +171,14 @@ jobs:
           chmod +x rvs_nightly_test.sh
           ./rvs_nightly_test.sh validate-config
 
-  install-rvs-on-target:
-    name: Install RVS on target node
-    needs: [detect-tarball, prepare-test-context]
-    runs-on: ${{ vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
-    timeout-minutes: 120
-    env:
-      TARBALL_URL:      ${{ needs.detect-tarball.outputs.tarball_url }}
-      TARBALL_NAME:     ${{ needs.detect-tarball.outputs.tarball_name }}
-      TARGET_NODE:      ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
-      TARGET_USER:      ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
-      TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RVS_TARGET_ROCM_PATH }}
-      REMOTE_WORK_DIR:  ${{ needs.prepare-test-context.outputs.remote_work_dir }}
-      ROCM_MAJOR:       ${{ needs.prepare-test-context.outputs.rocm_major }}
-      INSTALL_DIR:      ${{ needs.prepare-test-context.outputs.install_dir }}
-      RVS_BIN:          ${{ needs.prepare-test-context.outputs.rvs_bin }}
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
+      - name: Export paths for remaining steps
+        run: |
+          {
+            echo "REMOTE_WORK_DIR=${{ steps.prepare.outputs.remote_work_dir }}"
+            echo "ROCM_MAJOR=${{ steps.prepare.outputs.rocm_major }}"
+            echo "INSTALL_DIR=${{ steps.prepare.outputs.install_dir }}"
+            echo "RVS_BIN=${{ steps.prepare.outputs.rvs_bin }}"
+          } >> "$GITHUB_ENV"
 
       - name: Setup SSH for target node
         env:
@@ -191,14 +187,14 @@ jobs:
           chmod +x rvs_nightly_test.sh
           ./rvs_nightly_test.sh setup-ssh
 
-      - name: Verify ROCm prerequisites on target node
-        run: ./rvs_nightly_test.sh verify-rocm
-
-      - name: Download tarball on runner
+      - name: Download tarball on orchestrator runner
         run: ./rvs_nightly_test.sh download-tarball
 
       - name: Copy tarball to target node
         run: ./rvs_nightly_test.sh copy-to-target
+
+      - name: Verify ROCm prerequisites on target node
+        run: ./rvs_nightly_test.sh verify-rocm
 
       - name: Install RVS on target node
         run: ./rvs_nightly_test.sh install-rvs
@@ -212,7 +208,7 @@ jobs:
 
   run-rvs-level-4:
     name: Run RVS level 4 on target node
-    needs: [detect-tarball, prepare-test-context, install-rvs-on-target]
+    needs: [install-rvs-on-target]
     runs-on: ${{ vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
     timeout-minutes: 180
     outputs:
@@ -222,15 +218,13 @@ jobs:
       rvs_version:          ${{ steps.versions.outputs.rvs_version }}
       target_rocm_version:  ${{ steps.versions.outputs.target_rocm_version }}
     env:
-      TARBALL_URL:      ${{ needs.detect-tarball.outputs.tarball_url }}
-      TARBALL_NAME:     ${{ needs.detect-tarball.outputs.tarball_name }}
       TARGET_NODE:      ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
       TARGET_USER:      ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
       TARGET_ROCM_PATH: ${{ inputs.target_rocm_path || vars.RVS_TARGET_ROCM_PATH }}
-      REMOTE_WORK_DIR:  ${{ needs.prepare-test-context.outputs.remote_work_dir }}
-      ROCM_MAJOR:       ${{ needs.prepare-test-context.outputs.rocm_major }}
-      INSTALL_DIR:      ${{ needs.prepare-test-context.outputs.install_dir }}
-      RVS_BIN:          ${{ needs.prepare-test-context.outputs.rvs_bin }}
+      REMOTE_WORK_DIR:  ${{ needs.install-rvs-on-target.outputs.remote_work_dir }}
+      ROCM_MAJOR:       ${{ needs.install-rvs-on-target.outputs.rocm_major }}
+      INSTALL_DIR:      ${{ needs.install-rvs-on-target.outputs.install_dir }}
+      RVS_BIN:          ${{ needs.install-rvs-on-target.outputs.rvs_bin }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -272,9 +266,9 @@ jobs:
 
   create-test-report:
     name: Create Test Report
-    needs: [detect-tarball, prepare-test-context, run-rvs-level-4]
+    needs: [install-rvs-on-target, run-rvs-level-4]
     runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
-    if: always() && !cancelled() && needs.detect-tarball.result == 'success' && needs.run-rvs-level-4.result != 'skipped'
+    if: always() && !cancelled() && needs.install-rvs-on-target.result == 'success' && needs.run-rvs-level-4.result != 'skipped'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -289,11 +283,11 @@ jobs:
       - name: Build test report
         id: report
         env:
-          TARBALL_URL:          ${{ needs.detect-tarball.outputs.tarball_url }}
-          TARBALL_NAME:         ${{ needs.detect-tarball.outputs.tarball_name }}
+          TARBALL_URL:          ${{ needs.install-rvs-on-target.outputs.tarball_url }}
+          TARBALL_NAME:         ${{ needs.install-rvs-on-target.outputs.tarball_name }}
           TARGET_ROCM_PATH:     ${{ inputs.target_rocm_path || vars.RVS_TARGET_ROCM_PATH }}
-          REMOTE_WORK_DIR:      ${{ needs.prepare-test-context.outputs.remote_work_dir }}
-          RVS_BIN:              ${{ needs.prepare-test-context.outputs.rvs_bin }}
+          REMOTE_WORK_DIR:      ${{ needs.install-rvs-on-target.outputs.remote_work_dir }}
+          RVS_BIN:              ${{ needs.install-rvs-on-target.outputs.rvs_bin }}
           RVS_LEVEL4_RC:        ${{ needs.run-rvs-level-4.outputs.rc }}
           RVS_LEVEL4_START:     ${{ needs.run-rvs-level-4.outputs.start }}
           RVS_LEVEL4_END:       ${{ needs.run-rvs-level-4.outputs.end }}

--- a/rvs_nightly_test.sh
+++ b/rvs_nightly_test.sh
@@ -14,7 +14,7 @@ Commands (workflow order):
   validate-config     Fail fast; emit prepare job outputs to GITHUB_OUTPUT
   setup-ssh           Write SSH key/config under RUNNER_TEMP and verify connectivity
   verify-rocm         Remote rocminfo + amd-smi on TARGET_ROCM_PATH
-  download-tarball    curl tarball to ./pkg/ on the orchestrator runner
+  download-tarball    curl tarball to ./pkg/ on the orchestrator runner only (never on SSH target)
   copy-to-target      scp tarball to REMOTE_WORK_DIR/pkg on target
   install-rvs         Extract tarball on target under INSTALL_DIR
   verify-rvs-binary   Remote ldd check on RVS_BIN
@@ -177,7 +177,8 @@ cmd_download_tarball() {
   require_env TARBALL_URL
   require_env TARBALL_NAME
   mkdir -p ./pkg
-  echo "Downloading: $TARBALL_URL"
+  echo "Downloading tarball on orchestrator runner (target node is not used for this fetch):"
+  echo "  $TARBALL_URL"
   curl -fL --max-time 600 -o "./pkg/${TARBALL_NAME}" "${TARBALL_URL}"
   ls -la ./pkg/
   file "./pkg/${TARBALL_NAME}" || true


### PR DESCRIPTION
only the orchestrator hits the index and downloads the .tar.gz; the target only gets the bits via scp, then ROCm checks, install, and level 4 run on target node.