### PR TITLE
TARBALL_URL was empty in the Create Test Report job, fixed it

### DIFF
--- a/.github/workflows/README_NIGHTLY_TESTS.md
+++ b/.github/workflows/README_NIGHTLY_TESTS.md
@@ -463,6 +463,7 @@ Watch the Actions tab for:
 | **Verify RVS binary library resolution on target node** fails with `not found` | A ROCm runtime library is missing or not in `RPATH` on the target. The step prints the `ldd` output; install the matching ROCm component (typically `rocm-llvm`, `rocm-core`, `hip-runtime-amd`). |
 | **Run RVS level 4 on target node** exits non-zero immediately (after both verify steps passed) | RVS plugin's own dependency missing on the target (e.g. `libpci3` on Debian). Check `rvs_level_4.log` in the artifact for the specific error. |
 | **Collect logs from target node** warns: `No log files retrieved from target node` | The level steps exited so early they didn't produce any output, or `$REMOTE_WORK_DIR` was wiped. Inspect the level-step logs in the run UI for the original error. |
+| **Create Test Report** / **Build test report**: `Required environment variable TARBALL_URL is not set` | The install job’s `tarball_url` output was empty when passed into the report job (often URLs with `%`, `&`, or other characters that break the old `echo "tarball_url=$URL"` → `GITHUB_OUTPUT` form). The workflow now writes that URL with delimiter syntax; upgrade to current `rvs-nightly-tests.yml`. The report step also tolerates a missing URL and still writes `SUMMARY.md` with the tarball filename. |
 | Cron skipped a day | GitHub may delay or drop schedules under high load. Run once manually via `workflow_dispatch` to validate. |
 
 ## Retargeting at a different node

--- a/.github/workflows/rvs-nightly-tests.yml
+++ b/.github/workflows/rvs-nightly-tests.yml
@@ -153,14 +153,20 @@ jobs:
           fi
           echo "$NAME" > last_tarball_marker.txt
 
+          # Use heredoc delimiter syntax so URLs with %, &, query strings, etc. are not
+          # truncated or dropped when propagated to other jobs via job outputs.
           {
-            echo "tarball_url=$URL"
+            echo "tarball_url<<RVS_NIGHTLY_TARBALL_URL"
+            printf '%s\n' "$URL"
+            echo "RVS_NIGHTLY_TARBALL_URL"
             echo "tarball_name=$NAME"
           } >> "$GITHUB_OUTPUT"
 
           # Later steps in this job read TARBALL_URL / TARBALL_NAME (download-tarball, etc.)
           {
-            echo "TARBALL_URL=$URL"
+            echo "TARBALL_URL<<RVS_NIGHTLY_TARBALL_URL"
+            printf '%s\n' "$URL"
+            echo "RVS_NIGHTLY_TARBALL_URL"
             echo "TARBALL_NAME=$NAME"
           } >> "$GITHUB_ENV"
 

--- a/rvs_nightly_test.sh
+++ b/rvs_nightly_test.sh
@@ -342,10 +342,17 @@ REMOTE
 
 cmd_build_report() {
   require_env TARBALL_NAME
-  require_env TARBALL_URL
   require_env TARGET_ROCM_PATH
   require_env REMOTE_WORK_DIR
   require_env RVS_BIN
+
+  # TARBALL_URL is optional: the report job reads it from install-rvs-on-target outputs.
+  # If that output was empty (e.g. legacy echo-to-GITHUB_OUTPUT with special URL chars),
+  # still emit SUMMARY.md with the tarball filename.
+  local tarball_url_display="${TARBALL_URL:-}"
+  if [ -z "$tarball_url_display" ]; then
+    tarball_url_display="_(unavailable — check install job resolve step / use heredoc GITHUB_OUTPUT for URLs with special characters)_"
+  fi
 
   local rc4="${RVS_LEVEL4_RC:-0}"
   local start="${RVS_LEVEL4_START:-}"
@@ -378,7 +385,7 @@ cmd_build_report() {
     echo "| Target ROCm path | \`${TARGET_ROCM_PATH}\` (version \`${target_rocm_version}\`) |"
     echo "| Remote work dir | \`${REMOTE_WORK_DIR}\` |"
     echo "| Tarball | \`${TARBALL_NAME}\` |"
-    echo "| Source URL | ${TARBALL_URL} |"
+    echo "| Source URL | ${tarball_url_display} |"
     echo "| RVS version | \`${rvs_version}\` |"
     echo "| Overall result | **${overall}** |"
     echo ""


### PR DESCRIPTION
chmod +x rvs_nightly_test.sh is only making the script executable; the real failure is build-report exiting because TARBALL_URL was empty in the Create Test Report job.

That job sets:

TARBALL_URL: ${{ needs.install-rvs-on-target.outputs.tarball_url }}

The install job used:

echo "tarball_url=$URL" >> "$GITHUB_OUTPUT"

For GitHub Actions, values with characters like %, &, or other tricky URL pieces can be lost or not propagated when written as a single name=value line. You then get an empty tarball_url job output, so the report job never sees TARBALL_URL even though the install job succeeded.