### PR TITLE
Fixed Create test report, so Create test report should get TARBALL_NAME

### DIFF
--- a/.github/workflows/rvs-pr-tests.yml
+++ b/.github/workflows/rvs-pr-tests.yml
@@ -192,6 +192,15 @@ jobs:
             echo "RVS_BIN=${{ steps.prepare.outputs.rvs_bin }}"
           } >> "$GITHUB_ENV"
 
+      # Job outputs can drop tarball_url/name when passed to create-test-report; artifact is reliable.
+      - name: Upload package metadata for report job
+        uses: actions/upload-artifact@v4
+        with:
+          name: rvs-pr-pkg-meta-${{ github.run_id }}
+          path: ./pkg-meta/
+          retention-days: 1
+          if-no-files-found: error
+
       - name: Setup SSH for target node
         env:
           SSH_PRIVATE_KEY: ${{ secrets.RVS_TARGET_SSH_KEY }}
@@ -292,6 +301,12 @@ jobs:
           name: rvs-pr-logs-${{ github.run_id }}
           path: ./reports
         continue-on-error: true
+
+      - name: Download package metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: rvs-pr-pkg-meta-${{ github.run_id }}
+          path: ./pkg-meta
 
       - name: Build test report
         id: report

--- a/rvs_pr_test.sh
+++ b/rvs_pr_test.sh
@@ -248,17 +248,13 @@ cmd_resolve_package_url() {
   fi
 
   if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    # Write each output in its own multiline block so GitHub never merges tarball_url
-    # body with the tarball_name line (which can leave tarball_name unset for job outputs).
+    # Heredoc for tarball_url (URLs may contain %, &, etc.); plain assignment for tarball_name
+    # (safe filename) — same pattern as rvs-nightly-tests.yml / rvs_nightly_test.sh.
     {
       echo "tarball_url<<RVS_PR_PACKAGE_URL"
       printf '%s\n' "$URL"
       echo "RVS_PR_PACKAGE_URL"
-    } >> "$GITHUB_OUTPUT"
-    {
-      echo "tarball_name<<RVS_PR_PKG_NAME"
-      printf '%s\n' "$NAME"
-      echo "RVS_PR_PKG_NAME"
+      echo "tarball_name=$NAME"
     } >> "$GITHUB_OUTPUT"
   fi
 
@@ -267,13 +263,14 @@ cmd_resolve_package_url() {
       echo "TARBALL_URL<<RVS_PR_PACKAGE_URL"
       printf '%s\n' "$URL"
       echo "RVS_PR_PACKAGE_URL"
-    } >> "$GITHUB_ENV"
-    {
-      echo "TARBALL_NAME<<RVS_PR_PKG_NAME"
-      printf '%s\n' "$NAME"
-      echo "RVS_PR_PKG_NAME"
+      echo "TARBALL_NAME=$NAME"
     } >> "$GITHUB_ENV"
   fi
+
+  # Artifact fallback for create-test-report when job outputs drop URL/name between jobs.
+  mkdir -p ./pkg-meta
+  printf '%s\n' "$NAME" > ./pkg-meta/tarball_name
+  printf '%s\n' "$URL" > ./pkg-meta/tarball_url
 
   echo "Package file : $NAME"
   echo "URL          : $URL"
@@ -594,7 +591,19 @@ REMOTE
   fi
 }
 
+load_pkg_meta_from_artifact() {
+  if [ -f ./pkg-meta/tarball_name ] && [ -z "${TARBALL_NAME:-}" ]; then
+    TARBALL_NAME="$(tr -d '\r' < ./pkg-meta/tarball_name)"
+    export TARBALL_NAME
+  fi
+  if [ -f ./pkg-meta/tarball_url ] && [ -z "${TARBALL_URL:-}" ]; then
+    TARBALL_URL="$(tr -d '\r' < ./pkg-meta/tarball_url)"
+    export TARBALL_URL
+  fi
+}
+
 cmd_build_report() {
+  load_pkg_meta_from_artifact
   # Job outputs sometimes drop tarball_name when tarball_url is multiline; recover from URL.
   if [ -z "${TARBALL_NAME:-}" ] && [ -n "${TARBALL_URL:-}" ]; then
     TARBALL_NAME="$(basename "${TARBALL_URL%%\?*}")"


### PR DESCRIPTION
The Create Test Report job was failing because TARBALL_NAME (and often TARBALL_URL) never made it from install-rvs-on-target to create-test-report. GitHub Actions job outputs are unreliable for multiline URLs, so the report step saw empty env vars and require_env TARBALL_NAME exited.