### PR TITLE
Fixing the issue of the skipped workflow being triggered

### DIFF
--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -587,55 +587,31 @@ jobs:
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
         env:
-          PKG_BASE: ${{ secrets.RVS_PR_DEB_PACKAGE_URL || secrets.RVS_PR_PACKAGE_URL }}
+          GITHUB_REF_NAME: ${{ github.ref_name }}
         uses: actions/github-script@v7
         with:
           script: |
-            const base = (process.env.PKG_BASE || '').trim().replace(/\/$/, '');
-            if (!base) {
-              core.setFailed('RVS_PR_DEB_PACKAGE_URL (or RVS_PR_PACKAGE_URL) is not set — cannot dispatch PR tests.');
-              return;
-            }
-            const low = base.toLowerCase();
-            if (low.endsWith('.deb') || low.endsWith('.tar.gz')) {
-              core.setFailed('PR package secret must be the …/rvs HTTPS base, not a direct .deb or .tar.gz URL.');
-              return;
-            }
-            const pr = context.payload.pull_request.number;
-            const runNumber = context.runNumber;
-            const candidates = [
-              `${base}/${pr}/merge/${runNumber}/manylinux_2_28`,
-              `${base}/${runNumber}/merge/${pr}/manylinux_2_28`,
-            ];
-            let listing = '';
-            for (const cand of candidates) {
-              const res = await fetch(`${cand}/`, {
-                headers: { 'User-Agent': 'RVS-PR-Dispatch/1.0' },
-                redirect: 'follow',
-              });
-              if (res.ok) {
-                listing = cand;
-                break;
-              }
-            }
-            if (!listing) {
-              core.setFailed(
-                `Could not reach a manylinux_2_28 listing for PR #${pr} build ${runNumber}. Tried:\n  `
-                  + candidates.map((c) => `  ${c}/`).join('\n'),
-              );
-              return;
-            }
-            const ref = context.payload.pull_request.base.ref;
-            // Pass package_url only — works with the workflow definition on the base branch
-            // (master may not yet define pr_number / build_run_number inputs).
+            const prNumber = String(context.payload.pull_request.number);
+            const buildRunNumber = String(context.runNumber);
+            // Pass identifiers only — manylinux listing probe runs on the self-hosted
+            // runner in rvs-pr-tests.yml (lab CDN egress). Use PR head ref so the
+            // dispatched workflow includes pr_number / build_run_number inputs.
+            const ref = context.payload.pull_request.head.ref;
+            const buildRefName = process.env.GITHUB_REF_NAME || '';
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'rvs-pr-tests.yml',
               ref,
-              inputs: { package_url: listing },
+              inputs: {
+                pr_number: prNumber,
+                build_run_number: buildRunNumber,
+                build_ref_name: buildRefName,
+              },
             });
-            core.info(`Dispatched RVS PR Tests for PR #${pr} (build run ${runNumber}) with package_url=${listing}/ on ref ${ref}`);
+            core.info(
+              `Dispatched RVS PR Tests for PR #${prNumber} (build run ${buildRunNumber}) on ref ${ref}`,
+            );
 
   create-release:
     name: Create Release Summary

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -542,13 +542,29 @@ jobs:
           script: |
             const ref = context.payload.pull_request?.base?.ref
               ?? context.ref.replace('refs/heads/', '');
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'rvs-nightly-tests.yml',
-              ref,
-              inputs: { trigger_event: context.eventName },
-            });
+            const inputs = { trigger_event: context.eventName };
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'rvs-nightly-tests.yml',
+                ref,
+                inputs,
+              });
+            } catch (error) {
+              if (error.status === 422 && String(error.message).includes('Unexpected inputs')) {
+                core.warning('rvs-nightly-tests.yml on ref does not define trigger_event — dispatching without it.');
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'rvs-nightly-tests.yml',
+                  ref,
+                  inputs: {},
+                });
+              } else {
+                throw error;
+              }
+            }
             core.info(`Dispatched RVS Nightly Tests (trigger_event=${context.eventName}) on ref ${ref}`);
 
       - name: Dispatch RVS Release Tests
@@ -570,23 +586,56 @@ jobs:
         if: >-
           github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          PKG_BASE: ${{ secrets.RVS_PR_DEB_PACKAGE_URL || secrets.RVS_PR_PACKAGE_URL }}
         uses: actions/github-script@v7
         with:
           script: |
+            const base = (process.env.PKG_BASE || '').trim().replace(/\/$/, '');
+            if (!base) {
+              core.setFailed('RVS_PR_DEB_PACKAGE_URL (or RVS_PR_PACKAGE_URL) is not set — cannot dispatch PR tests.');
+              return;
+            }
+            const low = base.toLowerCase();
+            if (low.endsWith('.deb') || low.endsWith('.tar.gz')) {
+              core.setFailed('PR package secret must be the …/rvs HTTPS base, not a direct .deb or .tar.gz URL.');
+              return;
+            }
+            const pr = context.payload.pull_request.number;
+            const runNumber = context.runNumber;
+            const candidates = [
+              `${base}/${pr}/merge/${runNumber}/manylinux_2_28`,
+              `${base}/${runNumber}/merge/${pr}/manylinux_2_28`,
+            ];
+            let listing = '';
+            for (const cand of candidates) {
+              const res = await fetch(`${cand}/`, {
+                headers: { 'User-Agent': 'RVS-PR-Dispatch/1.0' },
+                redirect: 'follow',
+              });
+              if (res.ok) {
+                listing = cand;
+                break;
+              }
+            }
+            if (!listing) {
+              core.setFailed(
+                `Could not reach a manylinux_2_28 listing for PR #${pr} build ${runNumber}. Tried:\n  `
+                  + candidates.map((c) => `  ${c}/`).join('\n'),
+              );
+              return;
+            }
             const ref = context.payload.pull_request.base.ref;
-            const prNumber = String(context.payload.pull_request.number);
-            const buildRunNumber = String(context.runNumber);
+            // Pass package_url only — works with the workflow definition on the base branch
+            // (master may not yet define pr_number / build_run_number inputs).
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'rvs-pr-tests.yml',
               ref,
-              inputs: {
-                pr_number: prNumber,
-                build_run_number: buildRunNumber,
-              },
+              inputs: { package_url: listing },
             });
-            core.info(`Dispatched RVS PR Tests for PR #${prNumber} (build run ${buildRunNumber}) on ref ${ref}`);
+            core.info(`Dispatched RVS PR Tests for PR #${pr} (build run ${runNumber}) with package_url=${listing}/ on ref ${ref}`);
 
   create-release:
     name: Create Release Summary

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -521,6 +521,73 @@ jobs:
           AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
           RVS_RUNNER_SUFFIX: manylinux_2_28
 
+  dispatch-post-build-tests:
+    name: Dispatch post-build test workflows
+    needs: [build-ubuntu, build-centos]
+    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    if: >-
+      always() && !cancelled() &&
+      needs.build-ubuntu.result == 'success' &&
+      needs.build-centos.result == 'success'
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Dispatch RVS Nightly Tests
+        if: >-
+          github.event_name == 'schedule' ||
+          (github.event_name == 'push' && (github.ref_name == 'main' || github.ref_name == 'master'))
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = context.payload.pull_request?.base?.ref
+              ?? context.ref.replace('refs/heads/', '');
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'rvs-nightly-tests.yml',
+              ref,
+              inputs: { trigger_event: context.eventName },
+            });
+            core.info(`Dispatched RVS Nightly Tests (trigger_event=${context.eventName}) on ref ${ref}`);
+
+      - name: Dispatch RVS Release Tests
+        if: startsWith(github.ref_name, 'release/')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = context.ref.replace('refs/heads/', '');
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'rvs-release-tests.yml',
+              ref,
+              inputs: {},
+            });
+            core.info(`Dispatched RVS Release Tests on ref ${ref}`);
+
+      - name: Dispatch RVS PR Tests
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = context.payload.pull_request.base.ref;
+            const prNumber = String(context.payload.pull_request.number);
+            const buildRunNumber = String(context.runNumber);
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'rvs-pr-tests.yml',
+              ref,
+              inputs: {
+                pr_number: prNumber,
+                build_run_number: buildRunNumber,
+              },
+            });
+            core.info(`Dispatched RVS PR Tests for PR #${prNumber} (build run ${buildRunNumber}) on ref ${ref}`);
+
   create-release:
     name: Create Release Summary
     needs: [build-ubuntu, build-centos]

--- a/.github/workflows/rvs-nightly-tests.yml
+++ b/.github/workflows/rvs-nightly-tests.yml
@@ -16,17 +16,17 @@ name: RVS Nightly Tests
 #
 # Triggers
 # --------
-# - workflow_run: after Build Relocatable Packages completes successfully
-#   (push to main/master, or scheduled package build)
-# - workflow_dispatch: manual run with optional overrides
+# - workflow_dispatch: manual run, or dispatched by Build Relocatable Packages
+#   after a successful push to main/master or scheduled package build
+# - trigger_event input (schedule|push) is set by the package-build dispatch step
 
 on:
-  workflow_run:
-    workflows: ["Build Relocatable Packages"]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
+      trigger_event:
+        description: 'Package-build event that triggered this run (schedule or push); empty for manual runs'
+        required: false
+        default: ''
       tarball_url:
         description: 'Override tarball URL (default: latest from index — secrets.RVS_TARBALL_INDEX_URL)'
         required: false
@@ -60,30 +60,8 @@ env:
   TARBALL_INDEX_URL: ${{ secrets.RVS_TARBALL_INDEX_URL }}
 
 jobs:
-  gate-nightly-trigger:
-    name: Gate (eligible triggers only)
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       (
-         (github.event.workflow_run.event == 'push' &&
-          (github.event.workflow_run.head_branch == 'main' || github.event.workflow_run.head_branch == 'master')) ||
-         github.event.workflow_run.event == 'schedule'
-       ))
-    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
-    steps:
-      - name: Confirm nightly test run
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            echo "Package build (${{ github.event.workflow_run.event }}) completed on branch: ${{ github.event.workflow_run.head_branch }}"
-          else
-            echo "Manual nightly test run (workflow_dispatch)"
-          fi
-
   install-rvs-on-target:
     name: Install RVS on target node
-    needs: gate-nightly-trigger
     runs-on: ${{ vars.RVS_NIGHTLY_INDEX_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
     timeout-minutes: 120
     outputs:
@@ -102,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Restore last-seen marker (scheduled build path)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule'
+        if: inputs.trigger_event == 'schedule'
         uses: actions/cache@v4
         with:
           path: last_tarball_marker.txt
@@ -117,7 +95,7 @@ jobs:
           # masks workflow env. Use inherited TARBALL_INDEX_URL inside the script.
           INPUT_URL: ${{ inputs.tarball_url }}
           EVENT_NAME: ${{ github.event_name }}
-          WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event || '' }}
+          WORKFLOW_RUN_EVENT: ${{ inputs.trigger_event }}
         run: |
           set -euo pipefail
 
@@ -194,7 +172,7 @@ jobs:
           echo "URL            : $URL"
 
       - name: Save last-seen marker (scheduled build path)
-        if: github.event_name == 'workflow_run' && github.event.workflow_run.event == 'schedule'
+        if: inputs.trigger_event == 'schedule'
         uses: actions/cache/save@v4
         with:
           path: last_tarball_marker.txt
@@ -340,7 +318,7 @@ jobs:
           GITHUB_RUN_ID:        ${{ github.run_id }}
           GITHUB_SERVER_URL:    ${{ github.server_url }}
           GITHUB_REPOSITORY:    ${{ github.repository }}
-          GITHUB_EVENT_NAME:    ${{ github.event_name }}
+          GITHUB_EVENT_NAME:    ${{ inputs.trigger_event || github.event_name }}
         run: |
           chmod +x rvs_nightly_test.sh
           mkdir -p ./reports

--- a/.github/workflows/rvs-pr-tests.yml
+++ b/.github/workflows/rvs-pr-tests.yml
@@ -1,11 +1,10 @@
 name: RVS PR Tests
 
 # Runs after a successful "Build Relocatable Packages" run on pull_request (dispatched
-# from that workflow with a resolved package_url), or on workflow_dispatch. Package URL:
-# for post-build dispatch, the build workflow resolves the manylinux_2_28 listing and
-# passes package_url. For manual runs, use package_url or secret (…/rvs base, listing,
-# direct .tar.gz, or .deb). Optional pr_number + build_run_number inputs resolve the
-# listing inside this workflow when package_url is unset. See README_PR_TESTS.md.
+# from that workflow with pr_number + build_run_number), or on workflow_dispatch.
+# Post-build dispatch does not resolve the package URL — the install job on the
+# self-hosted runner probes the manylinux_2_28 listing (curl, lab CDN egress).
+# Manual runs: package_url or secret. See README_PR_TESTS.md.
 #
 # Required repo configuration: README_PR_TESTS.md (same secrets/vars as nightly for SSH/ROCm).
 
@@ -18,6 +17,10 @@ on:
         default: ''
       build_run_number:
         description: 'Build workflow run number (post-build dispatch)'
+        required: false
+        default: ''
+      build_ref_name:
+        description: 'GITHUB_REF_NAME from the package build (<pr>/merge); set by post-build dispatch'
         required: false
         default: ''
       package_url:
@@ -71,7 +74,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Set package URL (manual or post-build dispatch)
+      - name: Set package URL (manual)
         if: inputs.pr_number == '' || inputs.build_run_number == ''
         env:
           PACKAGE_INPUT: ${{ inputs.package_url }}
@@ -92,12 +95,13 @@ jobs:
             echo "RVS_PR_PKG_URL"
           } >> "$GITHUB_ENV"
 
-      - name: Set package URL (after successful PR build)
+      - name: Resolve manylinux listing (post-build dispatch, self-hosted)
         if: inputs.pr_number != '' && inputs.build_run_number != ''
         env:
           SECRET_PKG: ${{ secrets.RVS_PR_DEB_PACKAGE_URL || secrets.RVS_PR_PACKAGE_URL }}
           PR_NUMBER: ${{ inputs.pr_number }}
           RUN_NUMBER: ${{ inputs.build_run_number }}
+          BUILD_REF_NAME: ${{ inputs.build_ref_name }}
         run: |
           set -euo pipefail
           python3 <<'PY'
@@ -116,12 +120,15 @@ jobs:
 
           pr = int(os.environ["PR_NUMBER"])
           run_number = int(os.environ["RUN_NUMBER"])
-          # Primary: matches .github/scripts/rvs-s3-upload-route.sh — rvs/<pr>/merge/<GITHUB_RUN_NUMBER>/manylinux_2_28
-          # Fallback: some mirrors use rvs/<run_number>/merge/<pr>/manylinux_2_28
-          candidates = [
+          ref_name = (os.environ.get("BUILD_REF_NAME") or "").strip()
+          # Primary: exact rvs-s3-upload-route.sh layout (rvs/${GITHUB_REF_NAME}/${GITHUB_RUN_NUMBER}/manylinux_2_28)
+          candidates = []
+          if ref_name:
+              candidates.append(f"{base}/{ref_name}/{run_number}/manylinux_2_28")
+          candidates.extend([
               f"{base}/{pr}/merge/{run_number}/manylinux_2_28",
               f"{base}/{run_number}/merge/{pr}/manylinux_2_28",
-          ]
+          ])
 
           def listing_reachable(url: str) -> bool:
               p = subprocess.run(

--- a/.github/workflows/rvs-pr-tests.yml
+++ b/.github/workflows/rvs-pr-tests.yml
@@ -1,22 +1,27 @@
 name: RVS PR Tests
 
-# Runs after a successful "Build Relocatable Packages" run on pull_request, or on
-# workflow_dispatch. Package URL: for workflow_run, derived from secrets.RVS_PR_DEB_PACKAGE_URL
-# (HTTPS …/rvs base) + PR number + triggering run number + manylinux path (same layout as
-# .github/scripts/rvs-s3-upload-route.sh). For manual runs, use package_url or secret (rvs/
-# root, …/manylinux_*/ listing, direct .tar.gz, or .deb). See README_PR_TESTS.md.
+# Runs after a successful "Build Relocatable Packages" run on pull_request (dispatched
+# from that workflow), or on workflow_dispatch. Package URL: for post-build dispatch,
+# derived from secrets.RVS_PR_DEB_PACKAGE_URL (HTTPS …/rvs base) + pr_number +
+# build_run_number inputs + manylinux path (same layout as
+# .github/scripts/rvs-s3-upload-route.sh). For manual runs, use package_url or secret.
+# See README_PR_TESTS.md.
 #
 # Required repo configuration: README_PR_TESTS.md (same secrets/vars as nightly for SSH/ROCm).
 
 on:
-  workflow_run:
-    workflows: ['Build Relocatable Packages']
-    types:
-      - completed
   workflow_dispatch:
     inputs:
+      pr_number:
+        description: 'PR number (set by Build Relocatable Packages post-build dispatch)'
+        required: false
+        default: ''
+      build_run_number:
+        description: 'Build workflow run number (post-build dispatch)'
+        required: false
+        default: ''
       package_url:
-        description: 'HTTPS …/rvs/ root, …/manylinux_*/ listing, direct *-Linux.tar.gz, or .deb (empty → secrets; not used for workflow_run — secret must be /rvs/ base)'
+        description: 'HTTPS …/rvs/ root, …/manylinux_*/ listing, direct *-Linux.tar.gz, or .deb (empty → secrets; not used when pr_number + build_run_number are set)'
         required: false
         default: ''
       target_node:
@@ -49,7 +54,6 @@ env:
 jobs:
   install-rvs-on-target:
     name: Install RVS on target node
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request')
     runs-on: ${{ vars.RVS_NIGHTLY_INDEX_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
     timeout-minutes: 120
     outputs:
@@ -68,7 +72,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set package URL (manual)
-        if: github.event_name == 'workflow_dispatch'
+        if: inputs.pr_number == '' || inputs.build_run_number == ''
         env:
           PACKAGE_INPUT: ${{ inputs.package_url }}
           SECRET_PKG: ${{ secrets.RVS_PR_DEB_PACKAGE_URL || secrets.RVS_PR_PACKAGE_URL }}
@@ -89,15 +93,14 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Set package URL (after successful PR build)
-        if: github.event_name == 'workflow_run'
+        if: inputs.pr_number != '' && inputs.build_run_number != ''
         env:
           SECRET_PKG: ${{ secrets.RVS_PR_DEB_PACKAGE_URL || secrets.RVS_PR_PACKAGE_URL }}
-          PR_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
-          RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          RUN_NUMBER: ${{ inputs.build_run_number }}
         run: |
           set -euo pipefail
           python3 <<'PY'
-          import json
           import os
           import subprocess
           import sys
@@ -108,14 +111,10 @@ jobs:
               sys.exit(1)
           low = base.lower()
           if low.endswith(".deb") or low.endswith(".tar.gz"):
-              print("::error::For Build workflow triggers, set the secret to the /rvs HTTPS base only, not a direct .deb or .tar.gz URL.", file=sys.stderr)
+              print("::error::For post-build dispatch, set the secret to the /rvs HTTPS base only, not a direct .deb or .tar.gz URL.", file=sys.stderr)
               sys.exit(1)
 
-          prs = json.loads(os.environ.get("PR_JSON") or "[]")
-          if not prs:
-              print("::error::workflow_run has no pull_requests in the payload (e.g. fork PR). Cannot infer rvs/…/manylinux_2_28 path.", file=sys.stderr)
-              sys.exit(1)
-          pr = int(prs[0]["number"])
+          pr = int(os.environ["PR_NUMBER"])
           run_number = int(os.environ["RUN_NUMBER"])
           # Primary: matches .github/scripts/rvs-s3-upload-route.sh — rvs/<pr>/merge/<GITHUB_RUN_NUMBER>/manylinux_2_28
           # Fallback: some mirrors use rvs/<run_number>/merge/<pr>/manylinux_2_28

--- a/.github/workflows/rvs-pr-tests.yml
+++ b/.github/workflows/rvs-pr-tests.yml
@@ -1,11 +1,11 @@
 name: RVS PR Tests
 
 # Runs after a successful "Build Relocatable Packages" run on pull_request (dispatched
-# from that workflow), or on workflow_dispatch. Package URL: for post-build dispatch,
-# derived from secrets.RVS_PR_DEB_PACKAGE_URL (HTTPS …/rvs base) + pr_number +
-# build_run_number inputs + manylinux path (same layout as
-# .github/scripts/rvs-s3-upload-route.sh). For manual runs, use package_url or secret.
-# See README_PR_TESTS.md.
+# from that workflow with a resolved package_url), or on workflow_dispatch. Package URL:
+# for post-build dispatch, the build workflow resolves the manylinux_2_28 listing and
+# passes package_url. For manual runs, use package_url or secret (…/rvs base, listing,
+# direct .tar.gz, or .deb). Optional pr_number + build_run_number inputs resolve the
+# listing inside this workflow when package_url is unset. See README_PR_TESTS.md.
 #
 # Required repo configuration: README_PR_TESTS.md (same secrets/vars as nightly for SSH/ROCm).
 
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Set package URL (manual)
+      - name: Set package URL (manual or post-build dispatch)
         if: inputs.pr_number == '' || inputs.build_run_number == ''
         env:
           PACKAGE_INPUT: ${{ inputs.package_url }}

--- a/.github/workflows/rvs-release-tests.yml
+++ b/.github/workflows/rvs-release-tests.yml
@@ -11,14 +11,10 @@ name: RVS Release Tests
 #
 # Triggers
 # --------
-# - workflow_run: after Build Relocatable Packages completes successfully on release/*
-# - workflow_dispatch: manual run with optional overrides
+# - workflow_dispatch: manual run, or dispatched by Build Relocatable Packages
+#   after a successful build on a release/* branch
 
 on:
-  workflow_run:
-    workflows: ["Build Relocatable Packages"]
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       tarball_url:
@@ -54,22 +50,8 @@ env:
   TARBALL_INDEX_URL: ${{ secrets.RVS_RELEASE_TARBALL_INDEX_URL }}
 
 jobs:
-  gate-release-trigger:
-    name: Gate (release builds only)
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'release/'))
-    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
-    steps:
-      - name: Confirm release test run
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            echo "Release build completed on branch: ${{ github.event.workflow_run.head_branch }}"
-          else
-            echo "Manual release test run (workflow_dispatch)"
-          fi
-
   install-rvs-on-target:
     name: Install RVS on target node
-    needs: gate-release-trigger
     runs-on: ${{ vars.RVS_RELEASE_INDEX_RUNNER_LABEL || vars.RVS_NIGHTLY_INDEX_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
     timeout-minutes: 120
     outputs:


### PR DESCRIPTION
Fixed the condition so that there won't be any skipped nightly/PR/release runs for builds that were never eligible.