### PR TITLE
AMD SMI was initialized multiple times

### DIFF
--- a/babel.so/src/rvs_module.cpp
+++ b/babel.so/src/rvs_module.cpp
@@ -74,7 +74,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/gm.so/src/rvs_module.cpp
+++ b/gm.so/src/rvs_module.cpp
@@ -88,7 +88,6 @@ extern "C" int   rvs_module_terminate(void) {
     pworker = nullptr;
   }
   RVSTRACE_
-  amdsmi_shut_down();
 
   return 0;
 }

--- a/gpup.so/src/rvs_module.cpp
+++ b/gpup.so/src/rvs_module.cpp
@@ -68,7 +68,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/gst.so/src/rvs_module.cpp
+++ b/gst.so/src/rvs_module.cpp
@@ -73,7 +73,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/iet.so/src/rvs_module.cpp
+++ b/iet.so/src/rvs_module.cpp
@@ -74,7 +74,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/include/gpu_util.h
+++ b/include/gpu_util.h
@@ -62,6 +62,29 @@ namespace rvs {
 class gpulist {
  public:
   static int Initialize();
+  /** Shut down AMD SMI once per process (paired with Initialize). */
+  static void Terminate();
+
+  /**
+   * RAII guard for rvs::exec::run() (CLI and API).
+   *
+   * Calls Terminate() when exec::run() returns by any path. Terminate() is
+   * idempotent, so this is a no-op on the normal -c / API path where
+   * module::terminate() already shut AMD SMI down.
+   *
+   * Required for -r and -m: those options call get_gpu_name() ->
+   * gpulist::Initialize() (amdsmi_init) while resolving the platform conf
+   * file, before module::initialize(). If conf lookup fails, exec returns
+   * early and never reaches module::terminate() — without this guard AMD SMI
+   * would stay initialized.
+   */
+  class RunGuard {
+   public:
+    RunGuard() = default;
+    ~RunGuard() { Terminate(); }
+    RunGuard(const RunGuard&) = delete;
+    RunGuard& operator=(const RunGuard&) = delete;
+  };
 
   static int location2gpu(const uint16_t LocationID, uint16_t* pGpuID);
   static int gpu2location(const uint16_t GpuID, uint16_t* pLocationID);

--- a/mem.so/src/rvs_module.cpp
+++ b/mem.so/src/rvs_module.cpp
@@ -84,7 +84,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/pbqt.so/src/rvs_module.cpp
+++ b/pbqt.so/src/rvs_module.cpp
@@ -75,7 +75,6 @@ extern "C" int rvs_module_init(void* pMi) {
 
 extern "C" int rvs_module_terminate(void) {
     rvs::hsa::Terminate();
-    amdsmi_shut_down();
     return 0;
 }
 

--- a/pebb.so/src/rvs_module.cpp
+++ b/pebb.so/src/rvs_module.cpp
@@ -79,7 +79,6 @@ extern "C" int   rvs_module_init(void* pMi) {
 extern "C" int   rvs_module_terminate(void) {
   rvs::lp::Log("[module_terminate] pebb rvs_module_terminate() - entered",
       rvs::logtrace);
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/peqt.so/src/rvs_module.cpp
+++ b/peqt.so/src/rvs_module.cpp
@@ -67,7 +67,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/perf.so/src/rvs_module.cpp
+++ b/perf.so/src/rvs_module.cpp
@@ -72,7 +72,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/pesm.so/src/rvs_module.cpp
+++ b/pesm.so/src/rvs_module.cpp
@@ -92,7 +92,6 @@ extern "C" int   rvs_module_terminate(void) {
       "[module_terminate] pesm rvs_module_terminate() - monitoring stopped",
                  rvs::logtrace);
   }
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/pulse.so/src/rvs_module.cpp
+++ b/pulse.so/src/rvs_module.cpp
@@ -75,7 +75,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/rvs/src/rvs_interface.cpp
+++ b/rvs/src/rvs_interface.cpp
@@ -27,6 +27,7 @@
 #include <include/rvs.h>
 #include <include/rvsinternal.h>
 #include <include/rvsexec.h>
+#include <include/rvsmodule.h>
 #include <map>
 #include <mutex>
 
@@ -291,6 +292,10 @@ rvs_status_t rvs_terminate(void) {
     return RVS_STATUS_INVALID_STATE;
   }
   rvs_state = RVS_STATE_UNINITIALIZED;
+
+  /* Ensure AMD SMI and loaded modules are torn down if the client skipped
+   * session destroy or exited without running module::terminate via exec. */
+  rvs::module::terminate();
 
   return RVS_STATUS_SUCCESS;
 }

--- a/rvs/src/rvs_interface.cpp
+++ b/rvs/src/rvs_interface.cpp
@@ -27,7 +27,6 @@
 #include <include/rvs.h>
 #include <include/rvsinternal.h>
 #include <include/rvsexec.h>
-#include <include/rvsmodule.h>
 #include <map>
 #include <mutex>
 
@@ -292,10 +291,6 @@ rvs_status_t rvs_terminate(void) {
     return RVS_STATUS_INVALID_STATE;
   }
   rvs_state = RVS_STATE_UNINITIALIZED;
-
-  /* Ensure AMD SMI and loaded modules are torn down if the client skipped
-   * session destroy or exited without running module::terminate via exec. */
-  rvs::module::terminate();
 
   return RVS_STATUS_SUCCESS;
 }

--- a/rvs/src/rvsexec.cpp
+++ b/rvs/src/rvsexec.cpp
@@ -39,6 +39,7 @@
 #include "include/rvsoptions.h"
 #include "include/rvstrace.h"
 #include "include/rvs_util.h"
+#include "include/gpu_util.h"
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -62,6 +63,8 @@ rvs::exec::~exec() {
  *
  */
 int rvs::exec::run() {
+  // Pairs with get_gpu_name() on -r/-m early exits; no-op after module::terminate on -c.
+  rvs::gpulist::RunGuard smi_guard;
   int     sts = 0;
   string  val;
   string  path;
@@ -408,6 +411,8 @@ int rvs::exec::set_callback(void (*callback)(const rvs_results_t * results, int 
  */
 int rvs::exec::run(std::map<std::string, std::string>& opt) {
 
+  // Same AMD SMI cleanup guarantee as CLI run(); no-op after module::terminate.
+  rvs::gpulist::RunGuard smi_guard;
   int     sts = 0;
   string  path;
   string  module;

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -41,6 +41,7 @@
 #include "include/rvsliblog.h"
 #include "include/rvsoptions.h"
 #include "include/rvs_util.h"
+#include "include/gpu_util.h"
 
 #define MODULE_NAME_CAPS "CLI"
 
@@ -378,6 +379,8 @@ int rvs::module::terminate() {
   }
 
   modulemap.clear();
+
+  rvs::gpulist::Terminate();
 
   return 0;
 }

--- a/smqt.so/src/rvs_module.cpp
+++ b/smqt.so/src/rvs_module.cpp
@@ -72,7 +72,6 @@ extern "C" int   rvs_module_init(void* pMi) {
 }
 
 extern "C" int   rvs_module_terminate(void) {
-  amdsmi_shut_down();
   return 0;
 }
 

--- a/src/gpu_util.cpp
+++ b/src/gpu_util.cpp
@@ -31,6 +31,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include <mutex>
 
 #include "amd_smi/amdsmi.h"
 #include "include/gpu_util.h"
@@ -47,6 +48,13 @@ std::vector<uint16_t> rvs::gpulist::node_id;
 std::vector<uint16_t> rvs::gpulist::domain_id;
 std::map<std::pair<uint16_t, uint16_t> , uint16_t> rvs::gpulist::domain_loc_map;
 std::vector<std::string> rvs::gpulist::pci_bdf;
+
+namespace {
+
+std::mutex smi_lifecycle_mutex;
+bool smi_initialized = false;
+
+}  // namespace
 
 const std::map<uint16_t, std::string> gpu_dev_map = {
   {0x74a1, "MI300X"},    // MI300X
@@ -587,7 +595,13 @@ int gpu_hip_to_node(int hip_index, int* node) {
  * @return 0 if successful, -1 otherwise
  **/
 int rvs::gpulist::Initialize() {
-  amdsmi_init(AMDSMI_INIT_AMD_GPUS);
+  {
+    std::lock_guard<std::mutex> lk(smi_lifecycle_mutex);
+    if (!smi_initialized) {
+      amdsmi_init(AMDSMI_INIT_AMD_GPUS);
+      smi_initialized = true;
+    }
+  }
   gpu_get_all_location_id(&location_id);
   gpu_get_all_gpu_id(&gpu_id);
   gpu_get_all_gpu_idx(&gpu_idx);
@@ -597,6 +611,15 @@ int rvs::gpulist::Initialize() {
   gpu_get_all_pci_bdf(pci_bdf);
 
   return 0;
+}
+
+void rvs::gpulist::Terminate() {
+  std::lock_guard<std::mutex> lk(smi_lifecycle_mutex);
+  if (!smi_initialized) {
+    return;
+  }
+  amdsmi_shut_down();
+  smi_initialized = false;
 }
 
 

--- a/src/gpu_util.cpp
+++ b/src/gpu_util.cpp
@@ -591,17 +591,34 @@ int gpu_hip_to_node(int hip_index, int* node) {
 }
 
 /**
- * @brief Initialize gpulist helper class
+ * @brief Initialize gpulist helper class (idempotent).
+ *
+ * First call inits AMD SMI and fills the GPU index tables. Later calls are
+ * a no-op until Terminate(). Returns -1 if amdsmi_init() fails.
+ *
  * @return 0 if successful, -1 otherwise
  **/
 int rvs::gpulist::Initialize() {
-  {
-    std::lock_guard<std::mutex> lk(smi_lifecycle_mutex);
-    if (!smi_initialized) {
-      amdsmi_init(AMDSMI_INIT_AMD_GPUS);
-      smi_initialized = true;
-    }
+  std::lock_guard<std::mutex> lk(smi_lifecycle_mutex);
+  if (smi_initialized) {
+    return 0;
   }
+
+  amdsmi_status_t status = amdsmi_init(AMDSMI_INIT_AMD_GPUS);
+  if (status != AMDSMI_STATUS_SUCCESS) {
+    return -1;
+  }
+  smi_initialized = true;
+
+  location_id.clear();
+  gpu_id.clear();
+  gpu_idx.clear();
+  device_id.clear();
+  node_id.clear();
+  domain_id.clear();
+  domain_loc_map.clear();
+  pci_bdf.clear();
+
   gpu_get_all_location_id(&location_id);
   gpu_get_all_gpu_id(&gpu_id);
   gpu_get_all_gpu_idx(&gpu_idx);
@@ -620,6 +637,15 @@ void rvs::gpulist::Terminate() {
   }
   amdsmi_shut_down();
   smi_initialized = false;
+
+  location_id.clear();
+  gpu_id.clear();
+  gpu_idx.clear();
+  device_id.clear();
+  node_id.clear();
+  domain_id.clear();
+  domain_loc_map.clear();
+  pci_bdf.clear();
 }
 
 

--- a/tst.so/src/rvs_module.cpp
+++ b/tst.so/src/rvs_module.cpp
@@ -72,7 +72,6 @@ extern "C" int rvs_module_init(void* pMi) {
 }
 
 extern "C" int rvs_module_terminate(void) {
-    amdsmi_shut_down();
     return 0;
 }
 


### PR DESCRIPTION
## Motivation
<!-- In RVS per run (module init, systemOverview(), get_gpu_name()) but shut down once — causing heap corruption and a post-summary segfault. -->

Fix — centralized AMD SMI lifecycle. One ownership and idempotent cleanup API to work with both CLI run as well as API and ensure multi module loads are handled (ufor -r and -m cases)

## Technical Details

amdsmi_init() called more than once in a process as of now and a single shutdoqwn() call at exit of a RVS module. This resulted in corrupted heap and causes a segfault. A mutex guard for amd smi as a resource ensures single init and cleanup path . This solves cases for : 

-  Multi module call in a single process: like -m or -r runs and also a conf file with many modules in it.
- Single action runs
- API based calls. 

## Rootcause
Typical RVS run is : 
```

- First init — gst module rvs_module_init() → gpulist::Initialize()
- Test runs and passes; action_destroy() cleans up rvs_blas
- Second init — end-of-run summary → systemOverview() → gpulist::Initialize() again 
- Single shutdown — module::terminate() → gst rvs_module_terminate() → amdsmi_shut_down()
```
This double init and single shutdown causes Clib heap corruption error. 
WIth the current PR: we use guard to init and shutdown smi. We ensure gpulist::Initialize() calls smi init and gpulist::Terminate() calls smi shutdown. gpulist::Terminate() is called from module::terminate() after unloading modules. 
For API cases, we add module::terminate() in rvs_terminate()   but since this is idempotent and a no-op in case SMI already shutdown.
Retaubed existing behavior in unit tests as they run as standalone binaries.
## Test Plan

Run rvs with a multi module conf on latest rocm,.


