### PR TITLE
update TransferBench to v1.66.03

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Full documentation for RVS is available at [ROCmValidationSuite.Readme](https://
 
 ### Added
 
+- Updated Transferbench to v1.66.03
 - Bundled TransferBench as a git submodule under `external/TransferBench` and ship the TransferBench CLI in the same DEB/RPM as `rvs`. The CLI is provided for compatibility with existing TransferBench-based workflows; new work should use RVS (via the `pebb`/`pbqt` modules) or the TransferBench API directly. Opt out of the CLI build with `-DBUILD_TRANSFERBENCH_CLI=OFF`.
 - Added the pulse stressor module (`pulse.so`) for GPU power pulse stress testing. **(Beta — not intended for production use.)**
 - Added support for MI350X QPX mode.


### PR DESCRIPTION
Adding a hipDeviceSynchronize after input hipMemcpy as hotfix on
TransferBench

