### PR TITLE
Cp pci domain fix

### DIFF
--- a/peqt.so/src/action.cpp
+++ b/peqt.so/src/action.cpp
@@ -264,6 +264,9 @@ bool peqt_action::get_gpu_all_pcie_capabilities(struct pci_dev *dev,
                 map<string, uint8_t>::iterator it_pb_pm_state =
                                 pb_op_pm_states_encodings_map.find
                                     (prop_name.substr(0, pos_pb_pm_state));
+				if (it_pb_pm_state == pb_op_pm_states_encodings_map.end()) {
+					continue;
+				}
                 uint8_t pb_op_pm_state = it_pb_pm_state->second;
 
                 std::size_t pos_pb_type =
@@ -273,11 +276,17 @@ bool peqt_action::get_gpu_all_pcie_capabilities(struct pci_dev *dev,
                                 pb_op_pm_types_encodings_map.find
                                     (prop_name.substr(pos_pb_pm_state + 1,
                                         pos_pb_type - pos_pb_pm_state - 1));
+				if (it_pb_type == pb_op_pm_types_encodings_map.end()) {
+					continue;
+				}
                 uint8_t pb_op_pm_type = it_pb_type->second;
 
                 map<string, uint8_t>::iterator it_pb_power_rail =
                                 pb_op_pm_power_rails_encodings_map.find
                                         (prop_name.substr(pos_pb_type + 1));
+				if (it_pb_power_rail == pb_op_pm_power_rails_encodings_map.end()) {
+					continue;
+				}
                 uint8_t pb_op_power_rail = it_pb_power_rail->second;
                 // query for power budgeting capabilities
                 get_pwr_budgeting(dev, pb_op_pm_state, pb_op_pm_type,
@@ -437,11 +446,11 @@ int peqt_action::run(void) {
       // computes the actual dev's location_id (sysfs entry)
       uint16_t dev_location_id = ((((uint16_t) (dev->bus)) << 8)
               | ((uint16_t)  (dev->dev)) << 3 | ((uint16_t)  (dev->func)) );
-
+      uint16_t dev_domain = static_cast<uint16_t>(dev->domain); 
         // check if this pci_dev corresponds to one of the AMD GPUs
       uint16_t gpu_id;
-      // if not and AMD GPU just continue
-      if (rvs::gpulist::location2gpu(dev_location_id, &gpu_id)) {
+      // if not an AMD GPU just continue
+		if (rvs::gpulist::domlocation2gpu(dev_domain, dev_location_id, &gpu_id)) {
         RVSTRACE_
         continue;
       }

--- a/pesm.so/src/worker.cpp
+++ b/pesm.so/src/worker.cpp
@@ -142,9 +142,11 @@ void Worker::run() {
       uint16_t dev_location_id =
         ((((uint16_t)(dev->bus)) << 8) | (((uint16_t)(dev->dev)) << 3) | ((uint16_t)(dev->func))) ;
 
+      uint16_t dev_domain = static_cast<uint16_t>(dev->domain);
+
       uint16_t gpu_id;
       // if not and AMD GPU just continue
-      if (rvs::gpulist::location2gpu(dev_location_id, &gpu_id))
+      if (rvs::gpulist::domlocation2gpu(dev_domain, dev_location_id, &gpu_id))
         continue;
 
       uint16_t gpu_idx;

--- a/smqt.so/src/action.cpp
+++ b/smqt.so/src/action.cpp
@@ -229,10 +229,11 @@ int smqt_action::run(void) {
     // computes the actual dev's location_id (sysfs entry)
     uint16_t dev_location_id = ((((uint16_t) (dev->bus)) << 8)
               | ((uint16_t)  (dev->dev)) << 3 | ((uint16_t)  (dev->func)) );
+    uint16_t dev_domain = static_cast<uint16_t>(dev->domain);
 
     uint16_t gpu_id;
     // if not and AMD GPU just continue
-    if (rvs::gpulist::location2gpu(dev_location_id, &gpu_id))
+    if (rvs::gpulist::domlocation2gpu(dev_domain, dev_location_id, &gpu_id))
       continue;
 
 #ifdef  RVS_UNIT_TEST

--- a/src/pci_caps.cpp
+++ b/src/pci_caps.cpp
@@ -393,7 +393,7 @@ void get_pwr_budgeting(struct pci_dev *dev, uint8_t pb_pm_state,
 
     snprintf(buff, PCI_CAP_DATA_MAX_BUF_SIZE, "%s", PCI_CAP_NOT_SUPPORTED);
 
-    if (cap_offset_pwbgd == 0 || dev->no_config_access || dev->access == NULL) {
+    if (cap_offset_pwbgd == 0 || dev->access == NULL) {
         return;
     }
 

--- a/src/pci_caps.cpp
+++ b/src/pci_caps.cpp
@@ -320,48 +320,36 @@ void get_vendor_id(struct pci_dev *dev, char *buff) {
  * @return 
  */
 void get_kernel_driver(struct pci_dev *dev, char *buff) {
-    char name[1024], *drv, *base;
+    char name[256];
+    char link_target[PCI_CAP_DATA_MAX_BUF_SIZE];
+    char *drv;
     int n;
 
-    buff[0] = '\0';
-
-    //returning from here as there are other ways, this is
-    //not supported any longer
-    //the more simpler way is sudo dkms status
     snprintf(buff, PCI_CAP_DATA_MAX_BUF_SIZE, "%s", PCI_CAP_NOT_SUPPORTED);
 
-    if (dev->access == NULL) {
+    if (dev == NULL) {
         return;
     }
 
-    if (dev->access->method != PCI_ACCESS_SYS_BUS_PCI) {
-        return;
-    }
-
-    base = pci_get_param(dev->access, const_cast<char *>("sysfs.path"));
-    if (!base || !base[0]) {
-        return;
-    }
-
-    n = snprintf(name, sizeof(name), "%s/devices/%04x:%02x:%02x.%d/driver",
-            base, dev->domain, dev->bus, dev->dev, dev->func);
+    n = snprintf(name, sizeof(name),
+            "/sys/bus/pci/devices/%04x:%02x:%02x.%d/driver",
+            dev->domain, dev->bus, dev->dev, dev->func);
     if (n < 0 || n >= static_cast<int>(sizeof(name))) {
         return;
     }
 
-    n = readlink(name, buff, PCI_CAP_DATA_MAX_BUF_SIZE);
+    n = readlink(name, link_target, PCI_CAP_DATA_MAX_BUF_SIZE - 1);
     if (n < 0) {
         return;
     }
 
-    if (n >= PCI_CAP_DATA_MAX_BUF_SIZE) {
-        return;
-    }
+    link_target[n] = '\0';
 
-    buff[n] = 0;
-
-    if ((drv = strrchr(buff, '/')) != NULL)
+    if ((drv = strrchr(link_target, '/')) != NULL) {
         snprintf(buff, PCI_CAP_DATA_MAX_BUF_SIZE, "%s", drv + 1);
+    } else {
+        snprintf(buff, PCI_CAP_DATA_MAX_BUF_SIZE, "%s", link_target);
+    }
 }
 
 /**
@@ -405,39 +393,43 @@ void get_pwr_budgeting(struct pci_dev *dev, uint8_t pb_pm_state,
 
     snprintf(buff, PCI_CAP_DATA_MAX_BUF_SIZE, "%s", PCI_CAP_NOT_SUPPORTED);
 
-    if (cap_offset_pwbgd != 0) {
-        i = 0;
-
-        do {
-            // Data select register size is 1 byte, it will select the DWORD(4 bytes)
-	    // from budgeting data register corresponding to state.
-	    // dont proceed if write to register fails
-            int rt = pci_write_byte(dev, cap_offset_pwbgd + PCI_PWR_DSR, i);
-	    if(!rt){// 0 indicates error in writing
-		++i;
-		continue;
-	    }
-            w = pci_read_word(dev, cap_offset_pwbgd + PCI_PWR_DATA);
-
-            if (!w)
-                return;
-
-            pb_act_pm_state = PCI_PWR_DATA_PM_STATE(w);
-            pb_act_type = PCI_PWR_DATA_TYPE(w);
-            pb_act_power_rail = PCI_PWR_DATA_RAIL(w);
-
-            if (pb_act_pm_state == pb_pm_state && pb_act_type == pb_type &&
-                                        pb_act_power_rail == pb_power_rail) {
-                base = PCI_PWR_DATA_BASE(w);
-                scale = PCI_PWR_DATA_SCALE(w);
-                snprintf(buff, PCI_CAP_DATA_MAX_BUF_SIZE, "%.3fW",
-                        base * pow(10, -scale));
-                return;
-            }
-
-            i++;
-        } while (i <= DSR_MAX_VAL); // DSR size is 1 byte, no need to run forever
+    if (cap_offset_pwbgd == 0 || dev->no_config_access || dev->access == NULL) {
+        return;
     }
+
+    i = 0;
+	do {
+        // Data select register size is 1 byte, it will select the DWORD(4 bytes)
+        // from budgeting data register corresponding to state.
+        // dont proceed if write to register fails
+        int rt = pci_write_byte(dev, cap_offset_pwbgd + PCI_PWR_DSR, i);
+        if (!rt) {  // 0 indicates error in writing
+            ++i;
+            continue;
+        }
+        w = pci_read_word(dev, cap_offset_pwbgd + PCI_PWR_DATA);
+
+        if (!w) {
+            ++i;
+            continue;
+        }
+
+        pb_act_pm_state = PCI_PWR_DATA_PM_STATE(w);
+        pb_act_type = PCI_PWR_DATA_TYPE(w);
+        pb_act_power_rail = PCI_PWR_DATA_RAIL(w);
+
+
+        if (pb_act_pm_state == pb_pm_state && pb_act_type == pb_type &&
+                                    pb_act_power_rail == pb_power_rail) {
+            base = PCI_PWR_DATA_BASE(w);
+            scale = PCI_PWR_DATA_SCALE(w);
+            snprintf(buff, PCI_CAP_DATA_MAX_BUF_SIZE, "%.3fW",
+                    base * pow(10, -scale));
+            return;
+        }
+
+        i++;
+    } while (i <= DSR_MAX_VAL); // DSR size is 1 byte, no need to run forever
 }
 
 /**


### PR DESCRIPTION
Fix PEQT segfault and kernel_driver detection on multi-domain PCIe systems

PEQT, SMQT, and PESM matched PCI devices to GPUs using only bus/dev/func
(location_id) and ignored the PCIe domain. On systems with multiple domains
(e.g. 0000: and 0001:), unrelated devices can share the same location_id
— a GPU at 0000:05:00.0 and a bridge at 0001:05:00.0 both map to 0x0500.
Those modules then ran PCIe capability queries on the wrong device; libpci
state (notably dev->access) was corrupted and get_kernel_driver() segfaulted
dereferencing it.

Use domlocation2gpu(domain, location_id) so only the intended GPU BDF is
matched.

Clanmup and Hardening changes:
- get_kernel_driver: read /sys/bus/pci/devices/<BDF>/driver instead of
  libpci dev->access/readlink, avoiding bad access pointers while still
  reporting amdgpu.
- get_pwr_budgeting: skip when config access is unavailable; continue the
  DSR loop on failed/empty reads instead of aborting mid-query.
- PEQT dynamic power-budget capabilities: validate map lookups before use.