### PR TITLE
Fix PBQT peer-only mode JSON GPU IDs and action result.

### DIFF
--- a/pbqt.so/src/action.cpp
+++ b/pbqt.so/src/action.cpp
@@ -540,7 +540,7 @@ int pbqt_action::create_threads() {
           if (prop_test_bandwidth) {
             valid_pairs.push_back({srcnode, dstnode, pbconn});
           } else {
-            log_json_data(std::to_string(gpu_id[srcnode]), std::to_string(gpu_id[j]), rvs::logresults,
+            log_json_data(std::to_string(gpu_id[i]), std::to_string(gpu_id[j]), rvs::logresults,
                 pbconn, "NA" );
           }
 

--- a/pbqt.so/src/action_run.cpp
+++ b/pbqt.so/src/action_run.cpp
@@ -134,18 +134,30 @@ int pbqt_action::run() {
       return sts;
   }
 
-  if (!prop_test_bandwidth || test_array.size() < 1) {
+  if (!prop_test_bandwidth) {
     RVSTRACE_
-      // do cleanup
+    if (bjson) {
+      rvs::lp::JsonActionEndNodeCreate();
+    }
+
+    action_result.state = rvs::actionstate::ACTION_COMPLETED;
+    action_result.status = rvs::actionstatus::ACTION_SUCCESS;
+    action_result.output = "PBQT Module action " + action_name + " completed";
+    action_callback(&action_result);
+    return 0;
+  }
+
+  if (test_array.size() < 1) {
+    RVSTRACE_
       destroy_threads();
 
     action_result.state = rvs::actionstate::ACTION_COMPLETED;
     action_result.status = rvs::actionstatus::ACTION_FAILED;
     action_result.output = "Parameters not valid. Nothing to execute !!!";
     action_callback(&action_result);
-    if(bjson){
-    rvs::lp::JsonActionEndNodeCreate();
-  }
+    if (bjson) {
+      rvs::lp::JsonActionEndNodeCreate();
+    }
     return -1;
   }
 

--- a/rvs/conf/MI350P-450W/pbqt_single.conf
+++ b/rvs/conf/MI350P-450W/pbqt_single.conf
@@ -1,6 +1,6 @@
 # ################################################################################
 # #
-# # Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# # Copyright (c) 2026 Advanced Micro Devices, Inc. All rights reserved.
 # #
 # # MIT LICENSE:
 # # Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/rvs/conf/MI350P-450W/pbqt_single.conf
+++ b/rvs/conf/MI350P-450W/pbqt_single.conf
@@ -1,0 +1,118 @@
+# ################################################################################
+# #
+# # Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# #
+# # MIT LICENSE:
+# # Permission is hereby granted, free of charge, to any person obtaining a copy of
+# # this software and associated documentation files (the "Software"), to deal in
+# # the Software without restriction, including without limitation the rights to
+# # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# # of the Software, and to permit persons to whom the Software is furnished to do
+# # so, subject to the following conditions:
+# #
+# # The above copyright notice and this permission notice shall be included in all
+# # copies or substantial portions of the Software.
+# #
+# # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# # SOFTWARE.
+# #
+# ###############################################################################
+#
+# PBQT peer bandwidth tests for AMD Instinct MI350P (PCIe-attached).
+# MI350P GPUs are connected via PCIe (typical hop count 2), not XGMI. Do not use
+# MI350X configs: TransferBench all-to-all defaults to a2a_direct=1, which only
+# includes hop-count-1 (direct XGMI) pairs and yields no valid transfers on MI350P.
+#
+# Usage:
+#   ./rvs -c conf/MI350P-450W/pbqt_single.conf
+#   ./rvs -m pbqt
+
+actions:
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU unidirectional bandwidth test
+# using RVS native method via SDMA
+- name: pcie_d2d_unidir_bandwidth
+  device: all
+  module: pbqt
+  log_interval: 5000
+  duration: 30000
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU bidirectional bandwidth test
+# using RVS native method via SDMA
+- name: pcie_d2d_bidir_bandwidth
+  device: all
+  module: pbqt
+  log_interval: 5000
+  duration: 30000
+  peers: all
+  test_bandwidth: true
+  bidirectional: true
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU unidirectional bandwidth test
+# using TransferBench via SDMA
+- name: pcie_d2d_unidir_tb_dma
+  device: all
+  module: pbqt
+  duration: 0
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+  transfer_method: transferbench
+  executor: dma
+  subexecutor: 1
+  warm_calls: 2
+  hot_calls: 5
+
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU unidirectional bandwidth test
+# using TransferBench via GFX
+- name: pcie_d2d_unidir_tb_gfx
+  device: all
+  module: pbqt
+  duration: 0
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+  transfer_method: transferbench
+  executor: gfx
+  subexecutor: 16
+  warm_calls: 2
+  hot_calls: 5
+
+# All-to-All bandwidth test using TransferBench via GFX
+# a2a_direct: 0 — include PCIe-connected pairs (hop count > 1); default 1 is XGMI-only
+- name: pcie_d2d_unidir_tb_a2a
+  device: all
+  module: pbqt
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 268435456
+  device_id: all
+  transfer_method: transferbench
+  transferbench_test: alltoall
+  executor: gfx
+  subexecutor: 8
+  warm_calls: 3
+  hot_calls: 10
+  gfx_unroll: 2
+  a2a_direct: 0

--- a/rvs/conf/MI350P-450W/pebb_single.conf
+++ b/rvs/conf/MI350P-450W/pebb_single.conf
@@ -1,0 +1,127 @@
+# ################################################################################
+# #
+# # Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# #
+# # MIT LICENSE:
+# # Permission is hereby granted, free of charge, to any person obtaining a copy of
+# # this software and associated documentation files (the "Software"), to deal in
+# # the Software without restriction, including without limitation the rights to
+# # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# # of the Software, and to permit persons to whom the Software is furnished to do
+# # so, subject to the following conditions:
+# #
+# # The above copyright notice and this permission notice shall be included in all
+# # copies or substantial portions of the Software.
+# #
+# # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# # SOFTWARE.
+# #
+# ###############################################################################
+#
+# PEBB bandwidth tests for AMD Instinct MI350P (PCIe-attached).
+# Host/device transfers use link_type 2 (PCIe). Do not use MI350X configs on
+# MI350P; GPU-to-GPU topology differs (PCIe hop count 2 vs XGMI on MI350X).
+#
+# Usage:
+#   ./rvs -c conf/MI350P-450W/pebb_single.conf
+#   ./rvs -m pebb
+
+actions:
+# Host-to-Device/CPU-to-GPU bandwidth test using RVS native method via SDMA
+- name: pcie_h2d_bandwidth
+  device: all
+  module: pebb
+  duration: 30000
+  device_to_host: false
+  host_to_device: true
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+
+# Device-to-Host/GPU-to-CPU bandwidth test using RVS native method via SDMA
+- name: pcie_d2h_bandwidth
+  device: all
+  module: pebb
+  duration: 30000
+  device_to_host: true
+  host_to_device: false
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+
+# Host-to-Device/CPU-to-GPU bandwidth test using TransferBench via SDMA
+- name: pcie_h2d_bandwidth_tb_dma
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: false
+  host_to_device: true
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: dma
+  subexecutor: 1
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: cpu
+  destination_memory: gpu
+
+# Device-to-Host/GPU-to-CPU bandwidth test using TransferBench via SDMA
+- name: pcie_d2h_bandwidth_tb_dma
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: true
+  host_to_device: false
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: dma
+  subexecutor: 1
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: gpu
+  destination_memory: cpu
+
+# Host-to-Device/CPU-to-GPU bandwidth test using TransferBench via GFX
+- name: pcie_h2d_bandwidth_tb_gfx
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: false
+  host_to_device: true
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: gfx
+  subexecutor: 8
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: cpu
+  destination_memory: "null"
+
+# Device-to-Host/GPU-to-CPU bandwidth test using TransferBench via GFX
+- name: pcie_d2h_bandwidth_tb_gfx
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: true
+  host_to_device: false
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: gfx
+  subexecutor: 8
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: "null"
+  destination_memory: cpu

--- a/rvs/conf/MI350P-600W/pbqt_single.conf
+++ b/rvs/conf/MI350P-600W/pbqt_single.conf
@@ -1,0 +1,118 @@
+# ################################################################################
+# #
+# # Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# #
+# # MIT LICENSE:
+# # Permission is hereby granted, free of charge, to any person obtaining a copy of
+# # this software and associated documentation files (the "Software"), to deal in
+# # the Software without restriction, including without limitation the rights to
+# # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# # of the Software, and to permit persons to whom the Software is furnished to do
+# # so, subject to the following conditions:
+# #
+# # The above copyright notice and this permission notice shall be included in all
+# # copies or substantial portions of the Software.
+# #
+# # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# # SOFTWARE.
+# #
+# ###############################################################################
+#
+# PBQT peer bandwidth tests for AMD Instinct MI350P (PCIe-attached).
+# MI350P GPUs are connected via PCIe (typical hop count 2), not XGMI. Do not use
+# MI350X configs: TransferBench all-to-all defaults to a2a_direct=1, which only
+# includes hop-count-1 (direct XGMI) pairs and yields no valid transfers on MI350P.
+#
+# Usage:
+#   ./rvs -c conf/MI350P-600W/pbqt_single.conf
+#   ./rvs -m pbqt
+
+actions:
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU unidirectional bandwidth test
+# using RVS native method via SDMA
+- name: pcie_d2d_unidir_bandwidth
+  device: all
+  module: pbqt
+  log_interval: 5000
+  duration: 30000
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU bidirectional bandwidth test
+# using RVS native method via SDMA
+- name: pcie_d2d_bidir_bandwidth
+  device: all
+  module: pbqt
+  log_interval: 5000
+  duration: 30000
+  peers: all
+  test_bandwidth: true
+  bidirectional: true
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU unidirectional bandwidth test
+# using TransferBench via SDMA
+- name: pcie_d2d_unidir_tb_dma
+  device: all
+  module: pbqt
+  duration: 0
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+  transfer_method: transferbench
+  executor: dma
+  subexecutor: 1
+  warm_calls: 2
+  hot_calls: 5
+
+# Peer-to-Peer/Device-to-Device/GPU-to-GPU unidirectional bandwidth test
+# using TransferBench via GFX
+- name: pcie_d2d_unidir_tb_gfx
+  device: all
+  module: pbqt
+  duration: 0
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 1073741824
+  device_id: all
+  transfer_method: transferbench
+  executor: gfx
+  subexecutor: 16
+  warm_calls: 2
+  hot_calls: 5
+
+# All-to-All bandwidth test using TransferBench via GFX
+# a2a_direct: 0 — include PCIe-connected pairs (hop count > 1); default 1 is XGMI-only
+- name: pcie_d2d_unidir_tb_a2a
+  device: all
+  module: pbqt
+  peers: all
+  test_bandwidth: true
+  bidirectional: false
+  parallel: false
+  block_size: 268435456
+  device_id: all
+  transfer_method: transferbench
+  transferbench_test: alltoall
+  executor: gfx
+  subexecutor: 8
+  warm_calls: 3
+  hot_calls: 10
+  gfx_unroll: 2
+  a2a_direct: 0

--- a/rvs/conf/MI350P-600W/pebb_single.conf
+++ b/rvs/conf/MI350P-600W/pebb_single.conf
@@ -1,0 +1,127 @@
+# ################################################################################
+# #
+# # Copyright (c) 2025-2026 Advanced Micro Devices, Inc. All rights reserved.
+# #
+# # MIT LICENSE:
+# # Permission is hereby granted, free of charge, to any person obtaining a copy of
+# # this software and associated documentation files (the "Software"), to deal in
+# # the Software without restriction, including without limitation the rights to
+# # use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+# # of the Software, and to permit persons to whom the Software is furnished to do
+# # so, subject to the following conditions:
+# #
+# # The above copyright notice and this permission notice shall be included in all
+# # copies or substantial portions of the Software.
+# #
+# # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# # SOFTWARE.
+# #
+# ###############################################################################
+#
+# PEBB bandwidth tests for AMD Instinct MI350P (PCIe-attached).
+# Host/device transfers use link_type 2 (PCIe). Do not use MI350X configs on
+# MI350P; GPU-to-GPU topology differs (PCIe hop count 2 vs XGMI on MI350X).
+#
+# Usage:
+#   ./rvs -c conf/MI350P-600W/pebb_single.conf
+#   ./rvs -m pebb
+
+actions:
+# Host-to-Device/CPU-to-GPU bandwidth test using RVS native method via SDMA
+- name: pcie_h2d_bandwidth
+  device: all
+  module: pebb
+  duration: 30000
+  device_to_host: false
+  host_to_device: true
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+
+# Device-to-Host/GPU-to-CPU bandwidth test using RVS native method via SDMA
+- name: pcie_d2h_bandwidth
+  device: all
+  module: pebb
+  duration: 30000
+  device_to_host: true
+  host_to_device: false
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+
+# Host-to-Device/CPU-to-GPU bandwidth test using TransferBench via SDMA
+- name: pcie_h2d_bandwidth_tb_dma
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: false
+  host_to_device: true
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: dma
+  subexecutor: 1
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: cpu
+  destination_memory: gpu
+
+# Device-to-Host/GPU-to-CPU bandwidth test using TransferBench via SDMA
+- name: pcie_d2h_bandwidth_tb_dma
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: true
+  host_to_device: false
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: dma
+  subexecutor: 1
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: gpu
+  destination_memory: cpu
+
+# Host-to-Device/CPU-to-GPU bandwidth test using TransferBench via GFX
+- name: pcie_h2d_bandwidth_tb_gfx
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: false
+  host_to_device: true
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: gfx
+  subexecutor: 8
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: cpu
+  destination_memory: "null"
+
+# Device-to-Host/GPU-to-CPU bandwidth test using TransferBench via GFX
+- name: pcie_d2h_bandwidth_tb_gfx
+  device: all
+  module: pebb
+  duration: 0
+  device_to_host: true
+  host_to_device: false
+  parallel: false
+  block_size: 1073741824
+  link_type: 2
+  transfer_method: transferbench
+  executor: gfx
+  subexecutor: 8
+  warm_calls: 3
+  hot_calls: 10
+  source_memory: "null"
+  destination_memory: cpu


### PR DESCRIPTION

1. Use gpu_id[i] instead of gpu_id[srcnode] when logging peer connectivity JSON so srcgpu matches text logs on systems where HSA node IDs differ from enumeration indices.
2. Add MI350P pbqt/pebb configs,

