### PR TITLE
Remove the build-time amd-smi version check from the Dockerfile.

### DIFF
--- a/.github/docker/rvs-nightly-rocm/Dockerfile
+++ b/.github/docker/rvs-nightly-rocm/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p "${ROCM_INSTALL_PATH}" \
     && tar -xzf /tmp/rocm-sdk.tar.gz -C "${ROCM_INSTALL_PATH}" --strip-components=1 \
     && rm -f /tmp/rocm-sdk.tar.gz \
     && test -x "${ROCM_INSTALL_PATH}/bin/rocminfo" \
-    && "${ROCM_INSTALL_PATH}/bin/amd-smi" version
+    && test -x "${ROCM_INSTALL_PATH}/bin/amd-smi"
 
 COPY env-rocm.sh /etc/profile.d/rocm-env.sh
 


### PR DESCRIPTION
Removed the build-time amd-smi version check from the Dockerfile. GPU-dependent checks belong in verify-rocm at runtime, when the container has /dev/kfd and /dev/dri.