### PR TITLE
Removed docker building on host runner as transferring image to target node is taking very long

### DIFF
--- a/.github/docker/rvs-nightly-rocm/Dockerfile
+++ b/.github/docker/rvs-nightly-rocm/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p "${ROCM_INSTALL_PATH}" \
     && tar -xzf /tmp/rocm-sdk.tar.gz -C "${ROCM_INSTALL_PATH}" --strip-components=1 \
     && rm -f /tmp/rocm-sdk.tar.gz \
     && test -x "${ROCM_INSTALL_PATH}/bin/rocminfo" \
-    && "${ROCM_INSTALL_PATH}/bin/amd-smi" version
+    && test -x "${ROCM_INSTALL_PATH}/bin/amd-smi"
 
 COPY env-rocm.sh /etc/profile.d/rocm-env.sh
 

--- a/.github/workflows/rvs-nightly-docker-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-tests.yml
@@ -1,17 +1,25 @@
 name: RVS Nightly Tests (Docker)
 
-# Build ROCm docker image on the self-hosted runner, transfer to GPU target via
-# scp + docker load, then install RVS and run level 4 inside docker on the target.
+# Deliver a ROCm-matched docker image to the GPU target, install RVS, run level 4 in docker.
 # ROCm SDK version is derived from the tar tarball name (-rMMmm.yyyymmdd-Linux.tar.gz).
 #
-# Flow: build host docker build → docker save | scp → target docker load → target docker run
-# RVS tarball is wget'd inside the container on the target (no scp of RVS tar).
+# Default image delivery: build-on-target (docker build on the GPU node; no cross-host image transfer).
+# Set workflow input build_on_target=false to fall back to scp/registry delivery from the runner.
+#
+# Image delivery (RVS_DOCKER_TRANSFER_MODE / workflow input docker_transfer_mode):
+#   auto (default) — build-on-target when build_on_target is true (default), else registry when
+#                    RVS_DOCKER_REGISTRY is set, else scp (docker save | pigz/gzip | scp | docker load)
+#   scp            — always save/scp/load (skip when target already has matching ROCM_VERSION)
+#   registry       — docker push on build host, docker pull on target (requires RVS_DOCKER_REGISTRY)
+#   build-on-target — docker build on the GPU node (no cross-host image transfer)
+#
+# RVS tarball: downloaded on the orchestrator runner and scp'd to the target (not wget in container).
 #
 # Prerequisites:
-# - Build host (self-hosted runner): docker build user in docker group
-# - Target GPU node: docker, /dev/kfd, /dev/dri, SSH user in docker group
-# - Secrets: RVS_TARGET_NODE, RVS_TARGET_SSH_KEY (optional RVS_TARGET_USER)
-# - Secret: RVS_TARBALL_INDEX_URL
+# - Build host (self-hosted runner): curl/scp/ssh; HTTPS egress to tarball index (docker optional)
+# - Target GPU node: docker, HTTPS to rocm.nightlies.amd.com, /dev/kfd, /dev/dri, SSH user in docker group
+# - Secrets: RVS_TARGET_NODE, RVS_TARGET_SSH_KEY (optional RVS_TARGET_USER, RVS_TARBALL_INDEX_URL)
+# - Optional: vars.RVS_DOCKER_REGISTRY + secrets RVS_DOCKER_REGISTRY_USER/PASSWORD for registry mode
 #
 # See README_NIGHTLY_TESTS.md for SSH / tarball index configuration.
 
@@ -39,10 +47,19 @@ on:
         required: false
         default: ''
       build_docker_image:
-        description: 'Build rvs-nightly-rocm image on the build host from RVS tarball ROCm version before transfer'
+        description: 'Build rvs-nightly-rocm on the build host before scp/registry delivery (only when build_on_target is false)'
         required: false
         type: boolean
         default: false
+      build_on_target:
+        description: 'Build the ROCm docker image on the GPU target (default; skips cross-host image transfer)'
+        required: false
+        type: boolean
+        default: true
+      docker_transfer_mode:
+        description: 'Image delivery — auto, scp, registry, or build-on-target (default auto)'
+        required: false
+        default: 'auto'
       remote_work_dir:
         description: 'Work dir on target (default: /tmp/rvs-nightly-docker-<run_id>)'
         required: false
@@ -59,6 +76,12 @@ env:
   TARBALL_INDEX_URL: ${{ secrets.RVS_TARBALL_INDEX_URL }}
   RVS_NIGHTLY_DOCKER_IMAGE: ${{ inputs.docker_image || vars.RVS_NIGHTLY_DOCKER_IMAGE || 'rvs-nightly-rocm:latest' }}
   RVS_DOCKER_ON_TARGET: 'true'
+  RVS_DOCKER_TRANSFER_MODE: ${{ inputs.docker_transfer_mode || vars.RVS_DOCKER_TRANSFER_MODE || 'auto' }}
+  RVS_DOCKER_BUILD_ON_TARGET: ${{ (inputs.build_on_target != false) && (vars.RVS_DOCKER_BUILD_ON_TARGET != 'false') && 'true' || 'false' }}
+  RVS_DOCKER_REGISTRY: ${{ vars.RVS_DOCKER_REGISTRY || '' }}
+  RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
+  RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
+  RVS_DOCKER_SKIP_IF_PRESENT: 'true'
   TARGET_ROCM_PATH: /opt/rocm/install
   TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
   TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
@@ -66,7 +89,7 @@ env:
 
 jobs:
   install-rvs-in-docker:
-    name: Build image on runner and install RVS in docker on target
+    name: Ensure ROCm image on target and install RVS in docker
     runs-on: ${{ vars.RVS_NIGHTLY_DOCKER_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
     timeout-minutes: 180
     outputs:
@@ -152,6 +175,8 @@ jobs:
         run: ./rvs_nightly_test.sh setup-ssh
 
       - name: Export paths for remaining steps
+        env:
+          TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
         run: |
           {
             echo "REMOTE_WORK_DIR=${{ steps.prepare.outputs.remote_work_dir }}"
@@ -159,9 +184,12 @@ jobs:
             echo "INSTALL_DIR=${{ steps.prepare.outputs.install_dir }}"
             echo "RVS_BIN=${{ steps.prepare.outputs.rvs_bin }}"
           } >> "$GITHUB_ENV"
+          if [[ "$TARBALL_NAME" =~ -r([0-9]{2})([0-9]{2})\.([0-9]{8})-Linux\.tar\.gz$ ]]; then
+            echo "RVS_DOCKER_ROCM_VERSION=$((10#${BASH_REMATCH[1]})).$((10#${BASH_REMATCH[2]})).0a${BASH_REMATCH[3]}" >> "$GITHUB_ENV"
+          fi
 
       - name: Build ROCm docker image on build host
-        if: inputs.build_docker_image
+        if: inputs.build_docker_image && inputs.build_on_target == false
         env:
           TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
         run: |
@@ -169,12 +197,17 @@ jobs:
           ./.github/docker/rvs-nightly-rocm/build-rocm-image.sh --from-tarball "$TARBALL_NAME"
 
       - name: Verify ROCm docker image on build host
+        if: inputs.build_docker_image && inputs.build_on_target == false
         run: |
           chmod +x rvs_nightly_docker.sh
           ./rvs_nightly_docker.sh pull-image
 
-      - name: Transfer docker image to target (save, scp, load)
-        run: ./rvs_nightly_docker.sh transfer-image-to-target
+      - name: Ensure ROCm docker image on GPU target
+        env:
+          TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
+        run: |
+          chmod +x rvs_nightly_docker.sh
+          ./rvs_nightly_docker.sh ensure-image-on-target
 
       - name: Verify ROCm in docker on target
         run: ./rvs_nightly_docker.sh verify-rocm

--- a/rvs_nightly_docker.sh
+++ b/rvs_nightly_docker.sh
@@ -2,9 +2,18 @@
 ################################################################################
 # RVS nightly tests inside a ROCm-matched docker container.
 #
-# Default (RVS_DOCKER_ON_TARGET=true): build host saves the image,
-# scp + docker load on the GPU target, then docker run on the target via SSH.
+# Default (RVS_DOCKER_ON_TARGET=true): build the ROCm image on the GPU target
+# (RVS_DOCKER_BUILD_ON_TARGET=true) or deliver via scp/registry, then docker run via SSH.
 # Set RVS_DOCKER_ON_TARGET=false to run docker locally on the build host instead.
+#
+# Image delivery (RVS_DOCKER_TRANSFER_MODE):
+#   auto            build-on-target if RVS_DOCKER_BUILD_ON_TARGET=true, else registry
+#                   when RVS_DOCKER_REGISTRY is set, else scp (default path)
+#   scp             docker save | (pigz|gzip) | scp | docker load
+#   registry        docker push on build host, docker pull on target
+#   build-on-target docker build on the GPU node (no cross-host image transfer)
+#
+# Set RVS_DOCKER_SKIP_IF_PRESENT=false to force re-transfer/re-build.
 ################################################################################
 
 set -euo pipefail
@@ -12,22 +21,34 @@ set -euo pipefail
 DOCKER_IMAGE="${RVS_NIGHTLY_DOCKER_IMAGE:-rvs-nightly-rocm:latest}"
 DOCKER_IMAGE_ARCHIVE="${RVS_DOCKER_IMAGE_ARCHIVE:-rvs-nightly-rocm-image.tar.gz}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_BUILD_DIR="${REPO_ROOT}/.github/docker/rvs-nightly-rocm"
 
 usage() {
   cat <<'EOF'
 Usage: rvs_nightly_docker.sh <command>
 
-Image transfer (build host → target via scp + docker load):
-  transfer-image-to-target   docker save | gzip, scp, docker load on target
-  verify-image-on-target     Confirm image exists on target after load
+Image delivery (build host → target):
+  ensure-image-on-target     Skip, registry pull, scp load, or build on target (preferred)
+  transfer-image-to-target   Alias for ensure-image-on-target
+  build-image-on-target      Build rvs-nightly-rocm on the GPU target via SSH
+  verify-image-on-target     Confirm image exists on target
 
 In-container steps (on target when RVS_DOCKER_ON_TARGET=true):
-  pull-image                 Verify image on build host (local) before transfer
+  pull-image                 Verify image on build host (local) before scp/registry push
   verify-rocm                rocminfo + amd-smi inside container
   install-rvs                Extract RVS tarball under /opt/rocm/extras-<N>
   run-level4                 rvs -r 4 inside container
   capture-versions           Write rvs_version and target_rocm_version to GITHUB_OUTPUT
   run-pipeline               verify-rocm → install-rvs → run-level4
+
+Environment:
+  RVS_DOCKER_TRANSFER_MODE   auto | scp | registry | build-on-target (default: auto)
+  RVS_DOCKER_BUILD_ON_TARGET true (default) prefers build-on-target in auto mode
+  RVS_DOCKER_REGISTRY        e.g. ghcr.io/org/rvs-nightly-rocm (enables registry mode)
+  RVS_DOCKER_REGISTRY_USER   optional registry login user
+  RVS_DOCKER_REGISTRY_PASSWORD optional registry login password
+  RVS_DOCKER_ROCM_VERSION    expected ROCm SDK version (for skip-if-present matching)
+  RVS_DOCKER_SKIP_IF_PRESENT true (default) skips transfer when target already has image
 EOF
 }
 
@@ -68,6 +89,151 @@ require_ssh_config() {
     echo "::error::SSH config missing at $SSH_CONFIG_FILE — run: ./rvs_nightly_test.sh setup-ssh" >&2
     exit 1
   fi
+}
+
+phase_start() {
+  PHASE_LABEL="$1"
+  PHASE_START_TS=$(date +%s)
+  echo "::group::${PHASE_LABEL}"
+  echo "[$(date -u +%FT%TZ)] START ${PHASE_LABEL}"
+}
+
+phase_end() {
+  local elapsed=$(( $(date +%s) - PHASE_START_TS ))
+  echo "[$(date -u +%FT%TZ)] END ${PHASE_LABEL} (${elapsed}s)"
+  echo "::notice::${PHASE_LABEL} completed in ${elapsed}s"
+  echo "::endgroup::"
+}
+
+compress_pipe() {
+  if command -v pigz >/dev/null 2>&1; then
+    echo "::notice::Compressing with pigz"
+    pigz -1
+  else
+    echo "::notice::Compressing with gzip (install pigz for faster compression)"
+    gzip -1
+  fi
+}
+
+decompress_cmd() {
+  if command -v pigz >/dev/null 2>&1; then
+    pigz -dc
+  else
+    gzip -dc
+  fi
+}
+
+rocm_version_from_tarball() {
+  local base="${1##*/}"
+  if [[ "$base" =~ -r([0-9]{2})([0-9]{2})\.([0-9]{8})-Linux\.tar\.gz$ ]]; then
+    printf '%d.%d.0a%s\n' "$((10#${BASH_REMATCH[1]}))" "$((10#${BASH_REMATCH[2]}))" "${BASH_REMATCH[3]}"
+  fi
+}
+
+expected_rocm_version() {
+  if [ -n "${RVS_DOCKER_ROCM_VERSION:-}" ]; then
+    printf '%s\n' "$RVS_DOCKER_ROCM_VERSION"
+    return 0
+  fi
+  if [ -n "${TARBALL_NAME:-}" ]; then
+    rocm_version_from_tarball "$TARBALL_NAME"
+    return 0
+  fi
+  return 1
+}
+
+image_rocm_version_on_target() {
+  require_ssh_config
+  ssh -q -F "$SSH_CONFIG_FILE" rvs-target \
+    "docker image inspect '${DOCKER_IMAGE}' --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null" \
+    | sed -n 's/^ROCM_VERSION=//p' | head -1
+}
+
+resolve_transfer_mode() {
+  case "${RVS_DOCKER_TRANSFER_MODE:-auto}" in
+    scp|registry|build-on-target)
+      printf '%s\n' "${RVS_DOCKER_TRANSFER_MODE}"
+      ;;
+    auto)
+      case "${RVS_DOCKER_BUILD_ON_TARGET:-true}" in
+        0|false|False|no|NO)
+          if [ -n "${RVS_DOCKER_REGISTRY:-}" ]; then
+            printf '%s\n' registry
+          else
+            printf '%s\n' scp
+          fi
+          ;;
+        *)
+          printf '%s\n' build-on-target
+          ;;
+      esac
+      ;;
+    *)
+      echo "::error::Invalid RVS_DOCKER_TRANSFER_MODE: ${RVS_DOCKER_TRANSFER_MODE}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+registry_image_ref() {
+  local version="${1:-}"
+  local base="${RVS_DOCKER_REGISTRY%/}"
+  if [ -n "$version" ]; then
+    printf '%s:%s\n' "$base" "$version"
+  else
+    printf '%s\n' "$base"
+  fi
+}
+
+docker_registry_login() {
+  local where="$1"
+  if [ -z "${RVS_DOCKER_REGISTRY_USER:-}" ] || [ -z "${RVS_DOCKER_REGISTRY_PASSWORD:-}" ]; then
+    echo "::notice::No registry credentials set — assuming public pull/push for ${where}"
+    return 0
+  fi
+  local registry_host="${RVS_DOCKER_REGISTRY%%/*}"
+  case "$where" in
+    local)
+      echo "${RVS_DOCKER_REGISTRY_PASSWORD}" | docker login -u "${RVS_DOCKER_REGISTRY_USER}" \
+        --password-stdin "$registry_host"
+      ;;
+    target)
+      ssh -q -F "$SSH_CONFIG_FILE" rvs-target bash -s <<REMOTE
+echo '${RVS_DOCKER_REGISTRY_PASSWORD}' | docker login -u '${RVS_DOCKER_REGISTRY_USER}' --password-stdin '${registry_host}'
+REMOTE
+      ;;
+    *)
+      echo "::error::docker_registry_login: unknown location ${where}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+skip_if_present_enabled() {
+  case "${RVS_DOCKER_SKIP_IF_PRESENT:-true}" in
+    0|false|False|no|NO) return 1 ;;
+  esac
+  return 0
+}
+
+image_ready_on_target() {
+  require_ssh_config
+  check_docker_on_target
+  if ! ssh -q -F "$SSH_CONFIG_FILE" rvs-target "docker image inspect '${DOCKER_IMAGE}' >/dev/null 2>&1"; then
+    return 1
+  fi
+  local expected actual
+  expected="$(expected_rocm_version 2>/dev/null || true)"
+  if [ -z "$expected" ]; then
+    return 0
+  fi
+  actual="$(image_rocm_version_on_target || true)"
+  if [ "$actual" = "$expected" ]; then
+    echo "::notice::Target already has ${DOCKER_IMAGE} (ROCM_VERSION=${expected}) — skipping delivery"
+    return 0
+  fi
+  echo "Target image ROCM_VERSION=${actual:-unknown}; need ${expected} — delivery required"
+  return 1
 }
 
 target_rvs_install_dir() {
@@ -111,6 +277,9 @@ docker_run_local() {
     mkdir -p "$host_install"
     install_mount=(-v "${host_install}:${INSTALL_DIR}")
   fi
+  if [ -n "${TARBALL_NAME:-}" ] && [ -f "${REPO_ROOT}/pkg/${TARBALL_NAME}" ]; then
+    install_mount+=(-v "${REPO_ROOT}/pkg/${TARBALL_NAME}:/pkg/${TARBALL_NAME}:ro")
+  fi
   # shellcheck disable=SC2046
   docker run --rm \
     $(docker_gpu_opts) \
@@ -128,18 +297,23 @@ target_docker_run() {
   require_env REMOTE_WORK_DIR
   check_docker_on_target
   local inner_cmd="$1"
-  local gpu_opts install_vol escaped
+  local gpu_opts install_vol pkg_vol escaped
   gpu_opts=$(docker_gpu_opts)
   install_vol=""
+  pkg_vol=""
   if [ -n "${INSTALL_DIR:-}" ] && [ -n "${ROCM_MAJOR:-}" ]; then
     install_vol="-v ${REMOTE_WORK_DIR}/extras-${ROCM_MAJOR}:${INSTALL_DIR}"
+  fi
+  if [ -n "${TARBALL_NAME:-}" ]; then
+    pkg_vol="-v ${REMOTE_WORK_DIR}/pkg/${TARBALL_NAME}:/pkg/${TARBALL_NAME}:ro"
   fi
   escaped=$(printf '%q' "$inner_cmd")
   ssh -q -F "$SSH_CONFIG_FILE" rvs-target bash -s <<REMOTE
 set -euo pipefail
-mkdir -p '${REMOTE_WORK_DIR}/reports' '${REMOTE_WORK_DIR}/workspace'
+mkdir -p '${REMOTE_WORK_DIR}/reports' '${REMOTE_WORK_DIR}/workspace' '${REMOTE_WORK_DIR}/pkg'
 docker run --rm ${gpu_opts} \
   ${install_vol} \
+  ${pkg_vol} \
   -v '${REMOTE_WORK_DIR}/reports:/reports' \
   -v '${REMOTE_WORK_DIR}/workspace:/workspace' \
   -w /workspace \
@@ -166,27 +340,139 @@ cmd_pull_image() {
   fi
   echo "::error::Docker image ${DOCKER_IMAGE} not found on build host. Run:" >&2
   echo "  ./.github/docker/rvs-nightly-rocm/setup-on-runner.sh --from-tarball <tarball-name>" >&2
-  echo "Or re-run the workflow with build_docker_image=true." >&2
+  echo "Or re-run the workflow with build_docker_image=true (or build-on-target mode)." >&2
   exit 1
 }
 
-cmd_transfer_image_to_target() {
+cmd_build_image_on_target() {
+  require_ssh_config
+  require_env REMOTE_WORK_DIR
+  require_env TARBALL_NAME
+  check_docker_on_target
+
+  local remote_build_dir="${REMOTE_WORK_DIR}/docker-build"
+  phase_start "Sync docker build context to target"
+  ssh -q -F "$SSH_CONFIG_FILE" rvs-target "mkdir -p '${remote_build_dir}'"
+  scp -q -F "$SSH_CONFIG_FILE" -r "${DOCKER_BUILD_DIR}/." \
+    "rvs-target:${remote_build_dir}/"
+  phase_end "Sync docker build context to target"
+
+  phase_start "docker build on GPU target"
+  ssh -q -F "$SSH_CONFIG_FILE" rvs-target bash -s <<REMOTE
+set -euo pipefail
+chmod +x '${remote_build_dir}/build-rocm-image.sh'
+'${remote_build_dir}/build-rocm-image.sh' --from-tarball '${TARBALL_NAME}'
+REMOTE
+  phase_end "docker build on GPU target"
+  cmd_verify_image_on_target
+}
+
+cmd_transfer_via_registry() {
+  require_ssh_config
+  require_env REMOTE_WORK_DIR
+  require_env RVS_DOCKER_REGISTRY
+
+  local version ref
+  version="$(expected_rocm_version 2>/dev/null || true)"
+  ref="$(registry_image_ref "$version")"
+
+  cmd_pull_image
+  docker_registry_login local
+
+  phase_start "docker tag + push (${ref})"
+  docker tag "${DOCKER_IMAGE}" "${ref}"
+  docker push "${ref}"
+  if [ "$ref" != "${DOCKER_IMAGE}" ]; then
+    docker tag "${DOCKER_IMAGE}" "rvs-nightly-rocm:latest"
+  fi
+  phase_end "docker tag + push (${ref})"
+
+  phase_start "docker pull on target (${ref})"
+  docker_registry_login target
+  ssh -q -F "$SSH_CONFIG_FILE" rvs-target "docker pull '${ref}'"
+  ssh -q -F "$SSH_CONFIG_FILE" rvs-target "docker tag '${ref}' '${DOCKER_IMAGE}'"
+  phase_end "docker pull on target (${ref})"
+  cmd_verify_image_on_target
+}
+
+cmd_transfer_via_scp() {
   require_ssh_config
   require_env REMOTE_WORK_DIR
   cmd_pull_image
+
   local archive="${REPO_ROOT}/pkg/${DOCKER_IMAGE_ARCHIVE}"
   mkdir -p "${REPO_ROOT}/pkg"
-  echo "Saving ${DOCKER_IMAGE} to ${archive} ..."
-  docker save "${DOCKER_IMAGE}" | gzip -1 > "${archive}"
+
+  phase_start "docker save + compress (${DOCKER_IMAGE})"
+  docker save "${DOCKER_IMAGE}" | compress_pipe > "${archive}"
   ls -lh "${archive}"
+  phase_end "docker save + compress (${DOCKER_IMAGE})"
+
+  phase_start "scp image archive to target"
   ssh -q -F "$SSH_CONFIG_FILE" rvs-target "mkdir -p '${REMOTE_WORK_DIR}/docker'"
-  echo "Copying image archive to target:${REMOTE_WORK_DIR}/docker/ ..."
   scp -q -F "$SSH_CONFIG_FILE" "${archive}" \
     "rvs-target:${REMOTE_WORK_DIR}/docker/${DOCKER_IMAGE_ARCHIVE}"
-  echo "Loading image on target ..."
+  phase_end "scp image archive to target"
+
+  phase_start "docker load on target"
+  local decompress
+  decompress="$(decompress_cmd)"
   ssh -q -F "$SSH_CONFIG_FILE" rvs-target \
-    "gzip -dc '${REMOTE_WORK_DIR}/docker/${DOCKER_IMAGE_ARCHIVE}' | docker load"
+    "${decompress} '${REMOTE_WORK_DIR}/docker/${DOCKER_IMAGE_ARCHIVE}' | docker load"
+  phase_end "docker load on target"
   cmd_verify_image_on_target
+}
+
+cmd_download_rvs_tarball() {
+  require_env TARBALL_URL
+  require_env TARBALL_NAME
+  require_ssh_config
+  require_env REMOTE_WORK_DIR
+
+  local local_pkg="${REPO_ROOT}/pkg/${TARBALL_NAME}"
+  mkdir -p "${REPO_ROOT}/pkg"
+
+  phase_start "Download RVS tarball on orchestrator"
+  echo "  ${TARBALL_URL}"
+  curl -fL --max-time 600 -o "${local_pkg}" "${TARBALL_URL}"
+  file "${local_pkg}" || true
+  ls -lh "${local_pkg}"
+  phase_end "Download RVS tarball on orchestrator"
+
+  phase_start "scp RVS tarball to target"
+  ssh -q -F "$SSH_CONFIG_FILE" rvs-target "mkdir -p '${REMOTE_WORK_DIR}/pkg'"
+  scp -q -F "$SSH_CONFIG_FILE" "${local_pkg}" \
+    "rvs-target:${REMOTE_WORK_DIR}/pkg/${TARBALL_NAME}"
+  phase_end "scp RVS tarball to target"
+}
+
+cmd_ensure_image_on_target() {
+  require_ssh_config
+  require_env REMOTE_WORK_DIR
+
+  local mode
+  mode="$(resolve_transfer_mode)"
+  echo "Image delivery mode: ${mode}"
+
+  if skip_if_present_enabled && image_ready_on_target; then
+    return 0
+  fi
+
+  case "$mode" in
+    build-on-target)
+      if [ -z "${TARBALL_NAME:-}" ]; then
+        echo "::error::build-on-target requires TARBALL_NAME" >&2
+        exit 1
+      fi
+      cmd_build_image_on_target
+      ;;
+    registry)
+      cmd_transfer_via_registry
+      ;;
+    scp)
+      cmd_transfer_via_scp
+      ;;
+  esac
 }
 
 cmd_verify_image_on_target() {
@@ -196,7 +482,7 @@ cmd_verify_image_on_target() {
     echo "::notice::Image ${DOCKER_IMAGE} present on target node."
     return 0
   fi
-  echo "::error::Image ${DOCKER_IMAGE} not found on target after transfer." >&2
+  echo "::error::Image ${DOCKER_IMAGE} not found on target after delivery." >&2
   exit 1
 }
 
@@ -218,20 +504,31 @@ cmd_install_rvs() {
   require_env RVS_BIN
   require_env REMOTE_WORK_DIR
 
-  local url_escaped
-  url_escaped=$(printf '%q' "$TARBALL_URL")
+  if use_target_docker; then
+    cmd_download_rvs_tarball
+  else
+    local local_pkg="${REPO_ROOT}/pkg/${TARBALL_NAME}"
+    mkdir -p "${REPO_ROOT}/pkg"
+    if [ ! -f "${local_pkg}" ]; then
+      phase_start "Download RVS tarball locally"
+      curl -fL --max-time 600 -o "${local_pkg}" "${TARBALL_URL}"
+      phase_end "Download RVS tarball locally"
+    fi
+  fi
 
   docker_run "
     source /etc/profile.d/rocm-env.sh
     set -euo pipefail
-    PKG=/tmp/${TARBALL_NAME}
+    PKG=/pkg/${TARBALL_NAME}
     INSTALL_DIR=${INSTALL_DIR}
     RVS_BIN=${RVS_BIN}
-    echo \"Downloading RVS tarball inside container...\"
-    wget -q -O \"\${PKG}\" ${url_escaped}
+    if [ ! -f \"\${PKG}\" ]; then
+      echo \"::error::RVS tarball not mounted at \${PKG} — run download-rvs-tarball first\" >&2
+      exit 1
+    fi
+    echo \"Installing RVS from pre-staged tarball \${PKG}...\"
     mkdir -p \"\${INSTALL_DIR}\"
     tar -xzf \"\${PKG}\" -C \"\${INSTALL_DIR}\"
-    rm -f \"\${PKG}\"
     export LD_LIBRARY_PATH=\"\${INSTALL_DIR}/lib:\${LD_LIBRARY_PATH}\"
     if [ ! -x \"\${RVS_BIN}\" ]; then
       echo \"::error::rvs binary missing at \${RVS_BIN}\" >&2
@@ -330,8 +627,11 @@ main() {
   [ $# -ge 1 ] || { usage; exit 1; }
   case "$1" in
     pull-image)               cmd_pull_image ;;
-    transfer-image-to-target) cmd_transfer_image_to_target ;;
+    ensure-image-on-target)   cmd_ensure_image_on_target ;;
+    transfer-image-to-target) cmd_ensure_image_on_target ;;
+    build-image-on-target)    cmd_build_image_on_target ;;
     verify-image-on-target)   cmd_verify_image_on_target ;;
+    download-rvs-tarball)     cmd_download_rvs_tarball ;;
     verify-rocm)              cmd_verify_rocm ;;
     install-rvs)              cmd_install_rvs ;;
     run-level4)               cmd_run_level4 ;;


### PR DESCRIPTION


Image delivery overhaul (rvs_nightly_docker.sh + workflow): Default is now build-on-target (docker build on the GPU node, ~6 min vs ~2h+ scp); added skip-if-present, pigz, registry/scp modes, phase timing logs, and orchestrator download + scp for the RVS tarball .

Workflow updates: New inputs build_on_target (default true), docker_transfer_mode; job/steps renamed; host build only when build_on_target=false; optional registry vars/secrets for pull-based delivery.