### PR TITLE
Setting Default GPU_FAMILY to multiarch

### DIFF
--- a/.github/docker/rvs-nightly-rocm/Dockerfile
+++ b/.github/docker/rvs-nightly-rocm/Dockerfile
@@ -3,12 +3,12 @@
 #
 # Build on any docker host (typically the self-hosted runner):
 #   ./.github/docker/rvs-nightly-rocm/build-rocm-image.sh \
-#     --rocm-version 7.14.0a20260528 --gpu-family gfx110X-all
+#     --rocm-version 10.1.0a20260819 --gpu-family multiarch
 
 FROM ubuntu:24.04
 
 ARG ROCM_VERSION
-ARG GPU_FAMILY=gfx110X-all
+ARG GPU_FAMILY=multiarch
 ARG ROCM_SDK_BASE_URL
 ARG ROCM_INSTALL_PATH=/opt/rocm/install
 

--- a/.github/docker/rvs-nightly-rocm/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm/build-rocm-image.sh
@@ -3,8 +3,8 @@
 # Uses the same multiarch / release tarball URLs as build_packages_local.sh.
 #
 # Examples:
-#   ./build-rocm-image.sh --channel nightly --gpu-family gfx110X-all
-#   ./build-rocm-image.sh --rocm-version 7.14.0a20260528 --gpu-family gfx110X-all
+#   ./build-rocm-image.sh --channel nightly --gpu-family multiarch
+#   ./build-rocm-image.sh --rocm-version 10.1.0a20260819 --gpu-family multiarch
 #   ./build-rocm-image.sh --from-tarball amdrocm7-rvs-1.4.21-r0714.20260724-Linux.tar.gz
 #       (requires *-Linux.tar.gz with -rMMmm.yyyymmdd-; nightly pins exact 7.14.0a20260724 SDK)
 #   ./build-rocm-image.sh --channel nightly --tag rvs-nightly-rocm:latest
@@ -14,7 +14,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 ROCM_VERSION=""
-GPU_FAMILY="${GPU_FAMILY:-gfx110X-all}"
+GPU_FAMILY="${GPU_FAMILY:-multiarch}"
 CHANNEL="nightly"
 IMAGE_TAG=""
 ROCM_SDK_BASE_URL=""

--- a/.github/workflows/rvs-nightly-docker-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-tests.yml
@@ -18,6 +18,7 @@ name: RVS Nightly Tests (Docker)
 # Prerequisites:
 # - Build host (self-hosted runner): curl/scp/ssh; HTTPS egress to tarball index; checkout supplies docker build context
 # - Target GPU node: docker, HTTPS to rocm.nightlies.amd.com, /dev/kfd, /dev/dri, SSH user in docker group
+# - ROCm SDK in docker image: therock-dist-linux-multiarch-<version>.tar.gz (default GPU_FAMILY=multiarch)
 # - Secrets: RVS_TARGET_NODE, RVS_TARGET_SSH_KEY (optional RVS_TARGET_USER, RVS_TARBALL_INDEX_URL)
 # - Optional: vars.RVS_DOCKER_REGISTRY + secrets RVS_DOCKER_REGISTRY_USER/PASSWORD for registry mode
 #


### PR DESCRIPTION
ROCm SDK in docker: Default GPU_FAMILY changed from gfx110X-all to multiarch, so the image pulls therock-dist-linux-multiarch-<version>.tar.gz (includes gfx942/MI300X); Dockerfile also drops build-time amd-smi version (GPU check stays in verify-rocm).
