### PR TITLE
Fix potential security hole with rvs module load

### DIFF
--- a/include/rvs_util.h
+++ b/include/rvs_util.h
@@ -69,12 +69,12 @@ extern std::vector<std::string> str_split(const std::string& str_val,
 std::string rvs_get_rocm_install_path_string(void);
 
 /**
- * RVS data root .../share/.../rocm-validation-suite: RVS_PREFIX env, else path
- * derived from the running rvs process (e.g. prefix/bin/rvs) on Linux,
- * else the build-time RVS_DATA_ROOT macro. Install prefix is the parent of bin/.
+ * RVS data root .../share/.../rocm-validation-suite: path derived from the
+ * running rvs process (e.g. prefix/bin/rvs) on Linux, else build-time
+ * RVS_DATA_ROOT. Use -c to load a config from an arbitrary path.
  */
 std::string rvs_get_rvs_data_root_string(void);
-/** RVS module lib directory .../lib/rvs — same resolution order. */
+/** RVS module lib directory .../lib/rvs — same resolution order as data root. */
 std::string rvs_get_rvs_modules_lib_dir_string(void);
 
 /**

--- a/include/rvs_util.h
+++ b/include/rvs_util.h
@@ -69,13 +69,35 @@ extern std::vector<std::string> str_split(const std::string& str_val,
 std::string rvs_get_rocm_install_path_string(void);
 
 /**
- * RVS data root .../share/.../rocm-validation-suite: path derived from the
- * running rvs process (e.g. prefix/bin/rvs) on Linux, else build-time
- * RVS_DATA_ROOT. Use -c to load a config from an arbitrary path.
+ * @brief RVS data root (share/.../rocm-validation-suite).
+ *
+ * Path derived from the running rvs binary on Linux, else build-time
+ * RVS_DATA_ROOT. Use -c to load a config from an arbitrary location.
  */
 std::string rvs_get_rvs_data_root_string(void);
-/** RVS module lib directory .../lib/rvs — same resolution order as data root. */
+/**
+ * @brief RVS module library directory (.../lib/rvs).
+ *
+ * Same prefix resolution as rvs_get_rvs_data_root_string(). Final fallback
+ * when relative module search paths in rvsmodule.cpp do not find the .so.
+ */
 std::string rvs_get_rvs_modules_lib_dir_string(void);
+
+/**
+ * @brief Validate a module .so before dlopen().
+ *
+ * On Linux: regular file, not group/world writable. Ownership is checked only
+ * for non-root callers (must be owned by the effective user or root). When
+ * euid is 0 (root or sudo), any owner is allowed if permissions pass.
+ *
+ * @param path            Candidate .so path.
+ * @param err_msg         Optional failure reason.
+ * @param canonical_path  Optional canonical path on success.
+ * @return true if checks pass, false otherwise.
+ */
+bool rvs_verify_module_so_for_dlopen(const std::string& path,
+                                     std::string* err_msg,
+                                     std::string* canonical_path = nullptr);
 
 /**
  * Convert array of strings into array of signed integers of type T

--- a/rvs/src/rvsexec.cpp
+++ b/rvs/src/rvsexec.cpp
@@ -464,7 +464,7 @@ int rvs::exec::run(std::map<std::string, std::string>& opt) {
       config = "conf/" + module_config_file[module_index];
       std::ifstream file(path + config);
       if (!file.good()) {
-        // RVS data dir: from rvs binary, $RVS_PREFIX, or build-time RVS_DATA_ROOT
+        // RVS data dir: from rvs binary path or build-time RVS_DATA_ROOT
         path = rvs_get_rvs_data_root_string();
         config = "/conf/" + module_config_file[module_index];
       }

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -178,7 +178,7 @@ rvs::module* rvs::module::find_create_module(const char* name) {
       psolib = dlopen(sofullname.c_str(), RTLD_NOW);
       // error?
       if (!psolib) {
-        // RVS module lib dir: from rvs binary, $RVS_PREFIX, or build-time RVS_LIB_PATH
+        // RVS module lib dir: from rvs binary path or build-time RVS_LIB_PATH
         libpath = rvs_get_rvs_modules_lib_dir_string();
         libpath += "/";
         string sofullname(libpath + it->second);

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -44,6 +44,39 @@
 
 #define MODULE_NAME_CAPS "CLI"
 
+namespace {
+
+/**
+ * @brief dlopen a module .so after rvs_verify_module_so_for_dlopen().
+ *
+ * Runs verification first; on success opens the canonical path with RTLD_NOW.
+ * Returns nullptr and sets err_msg when verification or dlopen fails. Used for
+ * all three module search paths in find_create_module().
+ *
+ * @param so_path  Candidate .so path.
+ * @param err_msg  Optional; verification or dlopen failure reason.
+ * @return dlopen handle, or nullptr on failure.
+ */
+void* rvs_dlopen_verified_module(const std::string& so_path,
+                                 std::string* err_msg) {
+  std::string canonical;
+  std::string verify_err;
+  if (!rvs_verify_module_so_for_dlopen(so_path, &verify_err, &canonical)) {
+    if (err_msg) {
+      *err_msg = verify_err;
+    }
+    return nullptr;
+  }
+  void* handle = dlopen(canonical.c_str(), RTLD_NOW);
+  if (!handle && err_msg) {
+    const char* dl_err = dlerror();
+    *err_msg = dl_err ? dl_err : "dlopen failed";
+  }
+  return handle;
+}
+
+}  // namespace
+
 std::map<std::string, rvs::module*> rvs::module::modulemap;
 std::map<std::string, std::string>  rvs::module::filemap;
 YAML::Node rvs::module::config;
@@ -166,7 +199,8 @@ rvs::module* rvs::module::find_create_module(const char* name) {
     libpath += "../lib/rvs/";
 
     string sofullname(libpath + it->second);
-    void* psolib = dlopen(sofullname.c_str(), RTLD_NOW);
+    std::string load_err;
+    void* psolib = rvs_dlopen_verified_module(sofullname, &load_err);
     // error?
     if (!psolib) {
       //Search libraries in current path set in pwd option for backward compatibility
@@ -174,22 +208,22 @@ rvs::module* rvs::module::find_create_module(const char* name) {
         //Search libraries in current path if pwd option not set
         libpath = "./";
       } // has ending forward slash too
-      string sofullname(libpath + it->second);
-      psolib = dlopen(sofullname.c_str(), RTLD_NOW);
+      sofullname = libpath + it->second;
+      psolib = rvs_dlopen_verified_module(sofullname, &load_err);
       // error?
       if (!psolib) {
         // RVS module lib dir: from rvs binary path or build-time RVS_LIB_PATH
         libpath = rvs_get_rvs_modules_lib_dir_string();
         libpath += "/";
-        string sofullname(libpath + it->second);
-        psolib = dlopen(sofullname.c_str(), RTLD_NOW);
+        sofullname = libpath + it->second;
+        psolib = rvs_dlopen_verified_module(sofullname, &load_err);
         if (!psolib) {
           char buff[1024];
           snprintf(buff, sizeof(buff),
               "could not load .so '%s'", sofullname.c_str());
           rvs::logger::Err(buff, MODULE_NAME_CAPS);
           snprintf(buff, sizeof(buff),
-              "reason: '%s'", dlerror());
+              "reason: '%s'", load_err.c_str());
           rvs::logger::Err(buff, MODULE_NAME_CAPS);
           return NULL;  // fail
         }

--- a/src/rvs_util.cpp
+++ b/src/rvs_util.cpp
@@ -430,11 +430,6 @@ std::string rvs_linux_resolved_exe_path() {
 #endif
 
 std::string rvs_rvs_prefix_from_rvs_process() {
-  if (const char* pfx = std::getenv("RVS_PREFIX")) {
-    if (pfx[0] != '\0') {
-      return rvs_strip_trailing_slashes(std::string(pfx));
-    }
-  }
 #if defined(__linux__)
   const std::string exe = rvs_linux_resolved_exe_path();
   if (exe.empty() || rvs_path_basename(exe) != "rvs") {

--- a/src/rvs_util.cpp
+++ b/src/rvs_util.cpp
@@ -30,6 +30,7 @@
 #include <regex>
 #if defined(__linux__)
 #include <unistd.h>
+#include <sys/stat.h>
 #endif
 #include <iomanip>
 #include <algorithm>
@@ -414,6 +415,12 @@ std::string rvs_path_basename(const std::string& path) {
 }
 
 #if defined(__linux__)
+/**
+ * @brief Absolute path of the running rvs executable.
+ *
+ * Reads /proc/self/exe and resolves symlinks via realpath(). Returns empty
+ * string on failure.
+ */
 std::string rvs_linux_resolved_exe_path() {
   char linkbuf[4096] = {0};
   const ssize_t n = readlink("/proc/self/exe", linkbuf, sizeof(linkbuf) - 1);
@@ -429,6 +436,14 @@ std::string rvs_linux_resolved_exe_path() {
 }
 #endif
 
+/**
+ * @brief RVS install prefix derived from the running process.
+ *
+ * On Linux, if the executable is prefix/bin/rvs (or prefix/sbin/rvs),
+ * returns prefix. Does not consult RVS_PREFIX or other environment variables.
+ * Returns empty when the prefix cannot be inferred; callers fall back to
+ * build-time RVS_DATA_ROOT / RVS_LIB_PATH.
+ */
 std::string rvs_rvs_prefix_from_rvs_process() {
 #if defined(__linux__)
   const std::string exe = rvs_linux_resolved_exe_path();
@@ -446,6 +461,13 @@ std::string rvs_rvs_prefix_from_rvs_process() {
 
 }  // namespace
 
+/**
+ * @brief Directory containing RVS shared data (conf files, etc.).
+ *
+ * Resolution: install prefix from rvs_rvs_prefix_from_rvs_process() plus
+ * RVS_RELPATH_DATA_DIR, else compile-time RVS_DATA_ROOT. For configs outside
+ * this tree, use the -c command-line option.
+ */
 std::string rvs_get_rvs_data_root_string(void) {
   const std::string pfx = rvs_rvs_prefix_from_rvs_process();
   if (!pfx.empty()) {
@@ -454,11 +476,116 @@ std::string rvs_get_rvs_data_root_string(void) {
   return std::string(RVS_DATA_ROOT);
 }
 
+/**
+ * @brief Directory containing RVS module shared libraries (*.so).
+ *
+ * Resolution: install prefix from rvs_rvs_prefix_from_rvs_process() plus
+ * RVS_RELPATH_MODULE_LIB_DIR, else compile-time RVS_LIB_PATH. Used as the
+ * final fallback in rvsmodule.cpp after relative search paths fail.
+ */
 std::string rvs_get_rvs_modules_lib_dir_string(void) {
   const std::string pfx = rvs_rvs_prefix_from_rvs_process();
   if (!pfx.empty()) {
     return pfx + std::string("/") + RVS_RELPATH_MODULE_LIB_DIR;
   }
   return std::string(RVS_LIB_PATH);
+}
+
+#if defined(__linux__)
+/**
+ * @brief Resolve path to an absolute, symlink-free form.
+ *
+ * Wrapper around realpath(3). Used before stat/dlopen so module paths cannot
+ * be redirected through symlinks.
+ *
+ * @param path Input path (may be relative).
+ * @param out  Receives the canonical absolute path on success.
+ * @return true if resolution succeeded, false otherwise.
+ */
+bool rvs_canonical_path(const std::string& path, std::string* out) {
+  if (!out) {
+    return false;
+  }
+  char resolved[4096] = {0};
+  if (realpath(path.c_str(), resolved) == nullptr) {
+    return false;
+  }
+  *out = std::string(resolved);
+  return true;
+}
+#endif
+
+/**
+ * @brief Validate a module .so before dlopen().
+ *
+ * Security gate applied to every module load attempt. On Linux, checks that
+ * the target is a regular file, is not group- or world-writable, and passes
+ * ownership checks for non-root callers only (see implementation). Returns the
+ * canonical path so dlopen uses a stable, resolved location.
+ *
+ * @param path            Candidate .so path (relative or absolute).
+ * @param err_msg         Optional; receives a short reason on failure.
+ * @param canonical_path  Optional; receives realpath result on success.
+ * @return true if the file passes all checks, false otherwise.
+ */
+bool rvs_verify_module_so_for_dlopen(const std::string& path,
+                                     std::string* err_msg,
+                                     std::string* canonical_path) {
+#if defined(__linux__)
+  std::string canonical;
+  if (!rvs_canonical_path(path, &canonical)) {
+    if (err_msg) {
+      *err_msg = "could not resolve module path";
+    }
+    return false;
+  }
+
+  struct stat st;
+  if (stat(canonical.c_str(), &st) != 0) {
+    if (err_msg) {
+      *err_msg = "stat failed";
+    }
+    return false;
+  }
+
+  if (!S_ISREG(st.st_mode)) {
+    if (err_msg) {
+      *err_msg = "not a regular file";
+    }
+    return false;
+  }
+
+  if (st.st_mode & S_IWGRP) {
+    if (err_msg) {
+      *err_msg = "module is group-writable";
+    }
+    return false;
+  }
+
+  if (st.st_mode & S_IWOTH) {
+    if (err_msg) {
+      *err_msg = "module is world-writable";
+    }
+    return false;
+  }
+
+  const uid_t euid = geteuid();
+  if (euid != 0 && st.st_uid != euid && st.st_uid != 0) {
+    if (err_msg) {
+      *err_msg = "module owner mismatch";
+    }
+    return false;
+  }
+
+  if (canonical_path) {
+    *canonical_path = canonical;
+  }
+  return true;
+#else
+  if (canonical_path) {
+    *canonical_path = path;
+  }
+  return true;
+#endif
 }
 


### PR DESCRIPTION
## Motivation

With a potential to load rvs modules using dlopen from arbitrary location and without file verification can cause security issues.

Pre-dlopen verification (all load attempts)
| Check | Normal user | root / sudo |
| :--- | :---: | :--- |
| Path resolves via realpath() | Required | Required |
| Regular file | Required | Required |
| Not group-writable | Required | Required |
| Not world-writable | Required | Required |
| Ownership | Must be you or root | Any owner (no ownership check) |

Common scenarios
| Scenario | Works? |
| :--- | :--- |
| DEB/RPM install under `/opt/rocm/extras-*`, run as normal user | Yes |
| TGZ with `sudo tar … -C /opt/rocm/extras-*`, run as normal user | Yes |
| TGZ in `$HOME`, run as normal user | Yes (if you own the `.so` files) |
| Any install, `sudo rvs` | Yes (root/sudo skips ownership check) |
| `sudo rvs` against another user's install | Yes (if permissions pass) |
| Normal user loading another user's `.so` | No (module owner mismatch) |
| Group/world-writable `.so` | No (any caller) |
| Config from custom path | `-c /any/path/foo.conf` |


