### PR TITLE
commit hash based pull for external projects

### DIFF
--- a/CMakeGtestDownload.cmake
+++ b/CMakeGtestDownload.cmake
@@ -30,7 +30,8 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           v1.16.0
+  GIT_TAG           "6910c9d9165801d8827d628cb72eb7ea9dd538c5" #v1.16.0
+  GIT_CONFIG        "http.sslVerify=true" # Forces certificate validation
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/CMakePciutilsDownload.cmake
+++ b/CMakePciutilsDownload.cmake
@@ -30,7 +30,8 @@ project(pciutils-download NONE)
 include(ExternalProject)
 ExternalProject_Add(pciutils
   GIT_REPOSITORY    https://github.com/pciutils/pciutils.git
-  GIT_TAG           v3.7.0
+  GIT_TAG           "864aecdea9c7db626856d8d452f6c784316a878c" #Verion 3.7.0
+  GIT_CONFIG        "http.sslVerify=true" # Forces certificate validation
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/pciutils-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/pciutils-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
Pulling external projects using TAG and not having certificate validation might cause MITM attacks or other potential security issues.
