### PR TITLE
update permission/path check for local build

### DIFF
--- a/include/rvs_util.h
+++ b/include/rvs_util.h
@@ -86,9 +86,9 @@ std::string rvs_get_rvs_modules_lib_dir_string(void);
 /**
  * @brief Validate a module .so before dlopen().
  *
- * On Linux: regular file, not group/world writable. Ownership is checked only
- * for non-root callers (must be owned by the effective user or root). When
- * euid is 0 (root or sudo), any owner is allowed if permissions pass.
+ * On Linux: regular file, not world-writable; group-writable only when owned by
+ * the caller (local builds). When euid is 0, reject group/world writable and
+ * require root ownership.
  *
  * @param path            Candidate .so path.
  * @param err_msg         Optional failure reason.

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -46,6 +46,17 @@
 
 namespace {
 
+void rvs_prefer_load_err(std::string* keep, const std::string& next) {
+  if (next.empty()) {
+    return;
+  }
+  if (keep->empty() ||
+      (keep->find("could not resolve module path") != std::string::npos &&
+       next.find("could not resolve module path") == std::string::npos)) {
+    *keep = next;
+  }
+}
+
 /**
  * @brief dlopen a module .so after rvs_verify_module_so_for_dlopen().
  *
@@ -195,29 +206,47 @@ rvs::module* rvs::module::find_create_module(const char* name) {
 
     // open module .so library
     string libpath;
-    rvs::options::has_option("pwd", &libpath); // has ending forward slash too
-    libpath += "../lib/rvs/";
-
-    string sofullname(libpath + it->second);
     std::string load_err;
-    void* psolib = rvs_dlopen_verified_module(sofullname, &load_err);
-    // error?
-    if (!psolib) {
-      //Search libraries in current path set in pwd option for backward compatibility
-      if(false == rvs::options::has_option("pwd", &libpath)) {
-        //Search libraries in current path if pwd option not set
-        libpath = "./";
-      } // has ending forward slash too
-      sofullname = libpath + it->second;
+    void* psolib = nullptr;
+
+    // Dev build layout: modules live next to rvs in build/bin/
+    if (rvs::options::has_option("pwd", &libpath)) {
+      string sofullname(libpath + it->second);
       psolib = rvs_dlopen_verified_module(sofullname, &load_err);
-      // error?
+    }
+    if (!psolib) {
+      // Install layout: prefix/lib/rvs/
+      if (rvs::options::has_option("pwd", &libpath)) {
+        libpath += "../lib/rvs/";
+      } else {
+        libpath = "../lib/rvs/";
+      }
+      string sofullname(libpath + it->second);
+      std::string try_err;
+      psolib = rvs_dlopen_verified_module(sofullname, &try_err);
+      rvs_prefer_load_err(&load_err, try_err);
+    }
+    if (!psolib) {
+      // pwd-relative fallback for backward compatibility
+      if (rvs::options::has_option("pwd", &libpath)) {
+        // libpath reset to pwd by has_option
+      } else {
+        libpath = "./";
+      }
+      string sofullname(libpath + it->second);
+      std::string try_err;
+      psolib = rvs_dlopen_verified_module(sofullname, &try_err);
+      rvs_prefer_load_err(&load_err, try_err);
+    }
+    if (!psolib) {
+      // Final fallback: install prefix lib dir from rvs binary path or RVS_LIB_PATH
+      libpath = rvs_get_rvs_modules_lib_dir_string();
+      libpath += "/";
+      string sofullname(libpath + it->second);
+      std::string try_err;
+      psolib = rvs_dlopen_verified_module(sofullname, &try_err);
+      rvs_prefer_load_err(&load_err, try_err);
       if (!psolib) {
-        // RVS module lib dir: from rvs binary path or build-time RVS_LIB_PATH
-        libpath = rvs_get_rvs_modules_lib_dir_string();
-        libpath += "/";
-        sofullname = libpath + it->second;
-        psolib = rvs_dlopen_verified_module(sofullname, &load_err);
-        if (!psolib) {
           char buff[1024];
           snprintf(buff, sizeof(buff),
               "could not load .so '%s'", sofullname.c_str());
@@ -227,7 +256,6 @@ rvs::module* rvs::module::find_create_module(const char* name) {
           rvs::logger::Err(buff, MODULE_NAME_CAPS);
           return NULL;  // fail
         }
-      }
     }
     // create module object
     m = new rvs::module(name, psolib);

--- a/rvs/src/rvsmodule.cpp
+++ b/rvs/src/rvsmodule.cpp
@@ -62,7 +62,7 @@ void rvs_prefer_load_err(std::string* keep, const std::string& next) {
  *
  * Runs verification first; on success opens the canonical path with RTLD_NOW.
  * Returns nullptr and sets err_msg when verification or dlopen fails. Used for
- * all three module search paths in find_create_module().
+ * all four module search paths in find_create_module().
  *
  * @param so_path  Candidate .so path.
  * @param err_msg  Optional; verification or dlopen failure reason.

--- a/src/rvs_util.cpp
+++ b/src/rvs_util.cpp
@@ -519,9 +519,11 @@ bool rvs_canonical_path(const std::string& path, std::string* out) {
  * @brief Validate a module .so before dlopen().
  *
  * Security gate applied to every module load attempt. On Linux, checks that
- * the target is a regular file, is not group- or world-writable, and passes
- * ownership checks for non-root callers only (see implementation). Returns the
- * canonical path so dlopen uses a stable, resolved location.
+ * the target is a regular file, is not world-writable, and passes ownership
+ * and permission rules: group-writable is allowed only when the caller owns
+ * the file (typical local builds); when euid is 0, group/world writable
+ * modules are rejected and root ownership is required. Returns the canonical
+ * path so dlopen uses a stable, resolved location.
  *
  * @param path            Candidate .so path (relative or absolute).
  * @param err_msg         Optional; receives a short reason on failure.
@@ -584,9 +586,10 @@ bool rvs_verify_module_so_for_dlopen(const std::string& path,
       return false;
     }
     // Allow group-writable modules owned by the caller (typical for local builds).
-    if ((st.st_mode & S_IWGRP) && st.st_uid != euid) {
+    // st_uid is euid or 0 here; reject root-owned, group-writable system modules.
+    if ((st.st_mode & S_IWGRP) && st.st_uid == 0) {
       if (err_msg) {
-        *err_msg = "module is group-writable";
+        *err_msg = "root-owned module is group-writable";
       }
       return false;
     }

--- a/src/rvs_util.cpp
+++ b/src/rvs_util.cpp
@@ -555,13 +555,6 @@ bool rvs_verify_module_so_for_dlopen(const std::string& path,
     return false;
   }
 
-  if (st.st_mode & S_IWGRP) {
-    if (err_msg) {
-      *err_msg = "module is group-writable";
-    }
-    return false;
-  }
-
   if (st.st_mode & S_IWOTH) {
     if (err_msg) {
       *err_msg = "module is world-writable";
@@ -570,11 +563,33 @@ bool rvs_verify_module_so_for_dlopen(const std::string& path,
   }
 
   const uid_t euid = geteuid();
-  if (euid != 0 && st.st_uid != euid && st.st_uid != 0) {
-    if (err_msg) {
-      *err_msg = "module owner mismatch";
+  if (euid == 0) {
+    if (st.st_mode & S_IWGRP) {
+      if (err_msg) {
+        *err_msg = "module is group-writable";
+      }
+      return false;
     }
-    return false;
+    if (st.st_uid != 0) {
+      if (err_msg) {
+        *err_msg = "module is not owned by root";
+      }
+      return false;
+    }
+  } else {
+    if (st.st_uid != euid && st.st_uid != 0) {
+      if (err_msg) {
+        *err_msg = "module owner mismatch";
+      }
+      return false;
+    }
+    // Allow group-writable modules owned by the caller (typical for local builds).
+    if ((st.st_mode & S_IWGRP) && st.st_uid != euid) {
+      if (err_msg) {
+        *err_msg = "module is group-writable";
+      }
+      return false;
+    }
   }
 
   if (canonical_path) {


### PR DESCRIPTION
allow group-writable .so files when you own them (local builds). Still reject world-writable files; when running as root, still require root-owned, non-group-writable modules.

search build/bin/ first (dev layout),
then ../lib/rvs/ (install layout), then other fallbacks.

Better error reporting — prefer a specific verification error over a generic "could not resolve module path" when both occur.

