### PR TITLE
Added Ubuntu22 docker support

### DIFF
--- a/.github/docker/rvs-nightly-rocm-ubuntu22.04/Dockerfile
+++ b/.github/docker/rvs-nightly-rocm-ubuntu22.04/Dockerfile
@@ -1,0 +1,43 @@
+# ROCm nightly-test runtime image on Ubuntu 22.04 — same SDK tarball layout as build_packages_local.sh
+# (therock-dist-linux-<GPU_FAMILY>-<ROCM_VERSION>.tar.gz from multiarch or release listing).
+#
+# Build on any docker host (typically the self-hosted runner):
+#   ./.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh \
+#     --rocm-version 10.1.0a20260819 --gpu-family multiarch
+
+FROM ubuntu:22.04
+
+ARG ROCM_VERSION
+ARG GPU_FAMILY=multiarch
+ARG ROCM_SDK_BASE_URL
+ARG ROCM_INSTALL_PATH=/opt/rocm/install
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    wget \
+    tar \
+    pciutils \
+    kmod \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN test -n "${ROCM_VERSION}" && test -n "${ROCM_SDK_BASE_URL}"
+
+RUN mkdir -p "${ROCM_INSTALL_PATH}" \
+    && wget -q -O /tmp/rocm-sdk.tar.gz \
+         "${ROCM_SDK_BASE_URL%/}/therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz" \
+    && tar -xzf /tmp/rocm-sdk.tar.gz -C "${ROCM_INSTALL_PATH}" --strip-components=1 \
+    && rm -f /tmp/rocm-sdk.tar.gz \
+    && test -x "${ROCM_INSTALL_PATH}/bin/rocminfo" \
+    && test -x "${ROCM_INSTALL_PATH}/bin/amd-smi"
+
+COPY env-rocm.sh /etc/profile.d/rocm-env.sh
+
+ENV ROCM_PATH=${ROCM_INSTALL_PATH}
+ENV TARGET_ROCM_PATH=${ROCM_INSTALL_PATH}
+ENV ROCM_VERSION=${ROCM_VERSION}
+ENV GPU_FAMILY=${GPU_FAMILY}
+ENV UBUNTU_VERSION=22.04
+ENV LD_LIBRARY_PATH=${ROCM_INSTALL_PATH}/lib/rocm_sysdeps/lib:${ROCM_INSTALL_PATH}/lib/llvm/lib:${ROCM_INSTALL_PATH}/lib
+
+WORKDIR /workspace

--- a/.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Build (and tag) the ROCm runtime docker image for RVS nightly docker tests (Ubuntu 22.04).
+# Uses the same multiarch / release tarball URLs as build_packages_local.sh.
+#
+# Examples:
+#   ./build-rocm-image.sh --channel nightly --gpu-family multiarch
+#   ./build-rocm-image.sh --rocm-version 10.1.0a20260819 --gpu-family multiarch
+#   ./build-rocm-image.sh --from-tarball amdrocm10-rvs-1.7.10-r1001.20260819-Linux.tar.gz
+#   ./build-rocm-image.sh --channel nightly --tag rvs-nightly-rocm-ubuntu22.04:latest
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_REPO="${RVS_NIGHTLY_DOCKER_IMAGE:-rvs-nightly-rocm-ubuntu22.04:latest}"
+IMAGE_REPO="${IMAGE_REPO%%:*}"
+
+ROCM_VERSION=""
+GPU_FAMILY="${GPU_FAMILY:-multiarch}"
+CHANNEL="nightly"
+IMAGE_TAG=""
+ROCM_SDK_BASE_URL=""
+FROM_TARBALL=""
+
+NIGHTLY_INDEX="${ROCM_SDK_NIGHTLY_INDEX_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch/}"
+NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch}"
+RELEASE_LIST="${ROCM_SDK_RELEASE_URL:-https://repo.amd.com/rocm/tarball/}"
+RELEASE_BASE="${ROCM_SDK_RELEASE_BASE_URL:-https://repo.amd.com/rocm/tarball}"
+
+usage() {
+  sed -n '2,9p' "$0"
+  exit 1
+}
+
+resolve_sdk_base() {
+  local ver="$1"
+  if echo "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+a[0-9]+'; then
+    ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+  elif echo "$ver" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+    ROCM_SDK_BASE_URL="$RELEASE_BASE"
+  else
+    echo "::error::Unrecognized ROCm version format: $ver" >&2
+    exit 1
+  fi
+}
+
+fetch_latest_version() {
+  local mode="$1"
+  local listing_tmp versions
+  listing_tmp="$(mktemp)"
+  if [ "$mode" = "nightly" ]; then
+    wget -q -O "$listing_tmp" "$NIGHTLY_INDEX"
+    versions=$(grep -oE "therock-dist-linux-${GPU_FAMILY}-[0-9]+\.[0-9]+\.[0-9]+a[0-9]+" "$listing_tmp" \
+      | sed "s|^therock-dist-linux-${GPU_FAMILY}-||" | sort -V | tail -1)
+  else
+    wget -q -O "$listing_tmp" "$RELEASE_LIST"
+    versions=$(grep -oE "therock-dist-linux-${GPU_FAMILY}-[0-9]+\.[0-9]+\.[0-9]+" "$listing_tmp" \
+      | sed "s|^therock-dist-linux-${GPU_FAMILY}-||" | sort -V | tail -1)
+  fi
+  rm -f "$listing_tmp"
+  if [ -z "$versions" ]; then
+    echo "::error::No SDK version found for ${GPU_FAMILY} (${mode})" >&2
+    exit 1
+  fi
+  ROCM_VERSION="$versions"
+}
+
+resolve_rocm_from_tarball() {
+  local name="$1"
+  local base="${name##*/}"
+  local major minor build_date exact listing_tmp sdk_file prefix
+
+  if [[ "$base" != *-Linux.tar.gz ]]; then
+    echo "::error::--from-tarball requires a *-Linux.tar.gz relocatable tarball; got: ${base}" >&2
+    exit 1
+  fi
+
+  if [[ "$base" =~ -r([0-9]{2})([0-9]{2})\.([0-9]{8})-Linux\.tar\.gz$ ]]; then
+    major=$((10#${BASH_REMATCH[1]}))
+    minor=$((10#${BASH_REMATCH[2]}))
+    build_date="${BASH_REMATCH[3]}"
+  else
+    echo "::error::Cannot parse ROCm version from tar tarball (expected ...-rMMmm.yyyymmdd-Linux.tar.gz): ${base}" >&2
+    exit 1
+  fi
+
+  if [ "$CHANNEL" = "release" ]; then
+    prefix="${major}.${minor}."
+    listing_tmp="$(mktemp)"
+    wget -q -O "$listing_tmp" "$RELEASE_LIST"
+    ROCM_VERSION=$(grep -oE "therock-dist-linux-${GPU_FAMILY}-${prefix}[0-9]+" "$listing_tmp" \
+      | sed "s|^therock-dist-linux-${GPU_FAMILY}-||" | sort -V | tail -1)
+    rm -f "$listing_tmp"
+    sdk_file="therock-dist-linux-${GPU_FAMILY}-${ROCM_VERSION}.tar.gz"
+    resolve_sdk_base "$ROCM_VERSION"
+  else
+    exact="${major}.${minor}.0a${build_date}"
+    sdk_file="therock-dist-linux-${GPU_FAMILY}-${exact}.tar.gz"
+    listing_tmp="$(mktemp)"
+    wget -q -O "$listing_tmp" "$NIGHTLY_INDEX"
+    if ! grep -qF "$sdk_file" "$listing_tmp"; then
+      rm -f "$listing_tmp"
+      echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX})" >&2
+      exit 1
+    fi
+    rm -f "$listing_tmp"
+    ROCM_VERSION="$exact"
+    ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+  fi
+
+  if [ -z "$ROCM_VERSION" ]; then
+    echo "::error::No ${CHANNEL} SDK found for ROCm ${major}.${minor} (${GPU_FAMILY}) from tar ${base}" >&2
+    exit 1
+  fi
+  echo "Resolved ROCm ${ROCM_VERSION} from tar tarball ${base} (r$(printf '%02d%02d' "$major" "$minor").${build_date})"
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --rocm-version) ROCM_VERSION="$2"; shift 2 ;;
+    --from-tarball) FROM_TARBALL="$2"; shift 2 ;;
+    --gpu-family)   GPU_FAMILY="$2"; shift 2 ;;
+    --channel)      CHANNEL="$2"; shift 2 ;;
+    --tag)          IMAGE_TAG="$2"; shift 2 ;;
+    -h|--help)      usage ;;
+    *) echo "Unknown arg: $1" >&2; usage ;;
+  esac
+done
+
+if [ -n "$FROM_TARBALL" ]; then
+  resolve_rocm_from_tarball "$(basename "$FROM_TARBALL")"
+elif [ -z "$ROCM_VERSION" ]; then
+  fetch_latest_version "$CHANNEL"
+fi
+
+resolve_sdk_base "$ROCM_VERSION"
+IMAGE_TAG="${IMAGE_TAG:-${IMAGE_REPO}:${ROCM_VERSION}}"
+
+echo "Building docker image ${IMAGE_TAG}"
+echo "  ROCm version : ${ROCM_VERSION}"
+echo "  GPU family   : ${GPU_FAMILY}"
+echo "  SDK base URL : ${ROCM_SDK_BASE_URL}"
+echo "  Base OS      : Ubuntu 22.04"
+
+ROCM_INSTALL_PATH="${ROCM_INSTALL_PATH:-/opt/rocm/install}"
+
+docker build \
+  -f "${SCRIPT_DIR}/Dockerfile" \
+  --build-arg "ROCM_VERSION=${ROCM_VERSION}" \
+  --build-arg "GPU_FAMILY=${GPU_FAMILY}" \
+  --build-arg "ROCM_SDK_BASE_URL=${ROCM_SDK_BASE_URL}" \
+  --build-arg "ROCM_INSTALL_PATH=${ROCM_INSTALL_PATH}" \
+  -t "${IMAGE_TAG}" \
+  "${SCRIPT_DIR}"
+
+docker tag "${IMAGE_TAG}" "${IMAGE_REPO}:latest"
+echo "::notice::Tagged ${IMAGE_TAG} and ${IMAGE_REPO}:latest"

--- a/.github/docker/rvs-nightly-rocm-ubuntu22.04/env-rocm.sh
+++ b/.github/docker/rvs-nightly-rocm-ubuntu22.04/env-rocm.sh
@@ -1,0 +1,6 @@
+# Source in container shells: sets ROCm runtime paths (TheRock multiarch layout).
+ROCM_PATH="${ROCM_PATH:-/opt/rocm/install}"
+TARGET_ROCM_PATH="${TARGET_ROCM_PATH:-$ROCM_PATH}"
+export ROCM_PATH TARGET_ROCM_PATH
+export PATH="${ROCM_PATH}/bin:${PATH}"
+export LD_LIBRARY_PATH="${ROCM_PATH}/lib/rocm_sysdeps/lib:${ROCM_PATH}/lib/llvm/lib:${ROCM_PATH}/lib:${LD_LIBRARY_PATH:-}"

--- a/.github/docker/rvs-nightly-rocm-ubuntu22.04/setup-on-runner.sh
+++ b/.github/docker/rvs-nightly-rocm-ubuntu22.04/setup-on-runner.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Run on the self-hosted GPU runner host to build the Ubuntu 22.04 ROCm-matched docker image.
+#
+#   cd ROCmValidationSuite
+#   ./.github/docker/rvs-nightly-rocm-ubuntu22.04/setup-on-runner.sh --from-tarball amdrocm10-rvs-....tar.gz
+
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+chmod +x .github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
+exec .github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh "$@"

--- a/.github/workflows/build-relocatable-packages.yml
+++ b/.github/workflows/build-relocatable-packages.yml
@@ -603,6 +603,40 @@ jobs:
             }
             core.info(`Dispatched RVS Nightly Tests (trigger_event=${context.eventName}) on ref ${ref}`);
 
+      - name: Dispatch RVS Nightly Docker Tests (Ubuntu 24.04)
+        if: >-
+          github.event_name == 'push' &&
+          (github.ref_name == 'main' || github.ref_name == 'master')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = context.payload.pull_request?.base?.ref
+              ?? context.ref.replace('refs/heads/', '');
+            const inputs = { trigger_event: context.eventName };
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'rvs-nightly-docker-ubuntu24.04-tests.yml',
+                ref,
+                inputs,
+              });
+            } catch (error) {
+              if (error.status === 422 && String(error.message).includes('Unexpected inputs')) {
+                core.warning('rvs-nightly-docker-ubuntu24.04-tests.yml on ref does not define trigger_event — dispatching without it.');
+                await github.rest.actions.createWorkflowDispatch({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  workflow_id: 'rvs-nightly-docker-ubuntu24.04-tests.yml',
+                  ref,
+                  inputs: {},
+                });
+              } else {
+                throw error;
+              }
+            }
+            core.info(`Dispatched RVS Nightly Docker Tests Ubuntu 24.04 (trigger_event=${context.eventName}) on ref ${ref}`);
+
       - name: Dispatch RVS Release Tests
         if: startsWith(github.ref_name, 'release/')
         uses: actions/github-script@v7

--- a/.github/workflows/rvs-nightly-docker-ubuntu22.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu22.04-tests.yml
@@ -1,0 +1,329 @@
+name: RVS Nightly Tests (Docker Ubuntu 22.04)
+
+# Same flow as rvs-nightly-docker-ubuntu24.04-tests.yml but the ROCm runtime container uses ubuntu:22.04.
+# ROCm SDK version is derived from the tar tarball name (-rMMmm.yyyymmdd-Linux.tar.gz).
+#
+# Default image delivery: build-on-target (docker build on the GPU node; no cross-host image transfer).
+# Set workflow input build_on_target=false to fall back to scp/registry delivery from the runner.
+#
+# Image delivery (RVS_DOCKER_TRANSFER_MODE / workflow input docker_transfer_mode):
+#   auto (default) — build-on-target when build_on_target is true (default), else registry when
+#                    RVS_DOCKER_REGISTRY is set, else scp (docker save | pigz/gzip | scp | docker load)
+#   scp            — always save/scp/load (skip when target already has matching ROCM_VERSION)
+#   registry       — docker push on build host, docker pull on target (requires RVS_DOCKER_REGISTRY)
+#   build-on-target — docker build on the GPU node (no cross-host image transfer)
+#
+# RVS tarball: downloaded on the orchestrator runner and scp'd to the target (not wget in container).
+#
+# Prerequisites:
+# - Build host (self-hosted runner): curl/scp/ssh; HTTPS egress to tarball index; checkout supplies docker build context
+# - Target GPU node: docker, HTTPS to rocm.nightlies.amd.com, /dev/kfd, /dev/dri, SSH user in docker group
+# - ROCm SDK in docker image: therock-dist-linux-multiarch-<version>.tar.gz on ubuntu:22.04
+# - Secrets: RVS_TARGET_NODE, RVS_TARGET_SSH_KEY (optional RVS_TARGET_USER, RVS_TARBALL_INDEX_URL)
+# - Optional: vars.RVS_DOCKER_REGISTRY + secrets RVS_DOCKER_REGISTRY_USER/PASSWORD for registry mode
+#
+# See README_NIGHTLY_TESTS.md for SSH / tarball index configuration.
+
+on:
+  workflow_dispatch:
+    inputs:
+      trigger_event:
+        description: 'Label for report only (e.g. schedule or push); optional'
+        required: false
+        default: ''
+      tarball_url:
+        description: 'Override tarball URL (default: latest from index — secrets.RVS_TARBALL_INDEX_URL)'
+        required: false
+        default: ''
+      target_node:
+        description: 'GPU target hostname/IP (default: secrets.RVS_TARGET_NODE)'
+        required: false
+        default: ''
+      target_user:
+        description: 'SSH user on target (default: secrets.RVS_TARGET_USER)'
+        required: false
+        default: ''
+      docker_image:
+        description: 'ROCm runtime image (default: vars.RVS_NIGHTLY_DOCKER_UBUNTU22_IMAGE or rvs-nightly-rocm-ubuntu22.04:latest)'
+        required: false
+        default: ''
+      build_docker_image:
+        description: 'Build rvs-nightly-rocm-ubuntu22.04 on the build host before scp/registry delivery (only when build_on_target is false)'
+        required: false
+        type: boolean
+        default: false
+      build_on_target:
+        description: 'Build the ROCm docker image on the GPU target (default; skips cross-host image transfer)'
+        required: false
+        type: boolean
+        default: true
+      docker_transfer_mode:
+        description: 'Image delivery — auto, scp, registry, or build-on-target (default auto)'
+        required: false
+        default: 'auto'
+      remote_work_dir:
+        description: 'Work dir on target (default: /tmp/rvs-nightly-docker-ubuntu22.04-<run_id>)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rvs-nightly-docker-ubuntu22.04-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  TARBALL_INDEX_URL: ${{ secrets.RVS_TARBALL_INDEX_URL }}
+  RVS_NIGHTLY_DOCKER_IMAGE: ${{ inputs.docker_image || vars.RVS_NIGHTLY_DOCKER_UBUNTU22_IMAGE || 'rvs-nightly-rocm-ubuntu22.04:latest' }}
+  RVS_DOCKER_BUILD_DIR: .github/docker/rvs-nightly-rocm-ubuntu22.04
+  RVS_DOCKER_IMAGE_ARCHIVE: rvs-nightly-rocm-ubuntu22.04-image.tar.gz
+  RVS_DOCKER_ON_TARGET: 'true'
+  RVS_DOCKER_TRANSFER_MODE: ${{ inputs.docker_transfer_mode || vars.RVS_DOCKER_TRANSFER_MODE || 'auto' }}
+  RVS_DOCKER_BUILD_ON_TARGET: ${{ (inputs.build_on_target != false) && (vars.RVS_DOCKER_BUILD_ON_TARGET != 'false') && 'true' || 'false' }}
+  RVS_DOCKER_REGISTRY: ${{ vars.RVS_DOCKER_REGISTRY || '' }}
+  RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
+  RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
+  RVS_DOCKER_SKIP_IF_PRESENT: 'true'
+  TARGET_ROCM_PATH: /opt/rocm/install
+  TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
+  TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
+  SSH_PRIVATE_KEY: ${{ secrets.RVS_TARGET_SSH_KEY }}
+
+jobs:
+  install-rvs-in-docker:
+    name: Ensure ROCm image (Ubuntu 22.04) on target and install RVS in docker
+    runs-on: ${{ vars.RVS_NIGHTLY_DOCKER_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
+    timeout-minutes: 180
+    outputs:
+      tarball_url:      ${{ steps.resolve.outputs.tarball_url }}
+      tarball_name:     ${{ steps.resolve.outputs.tarball_name }}
+      remote_work_dir:  ${{ steps.prepare.outputs.remote_work_dir }}
+      rocm_major:       ${{ steps.prepare.outputs.rocm_major }}
+      install_dir:      ${{ steps.prepare.outputs.install_dir }}
+      rvs_bin:          ${{ steps.prepare.outputs.rvs_bin }}
+    env:
+      TARGET_ROCM_PATH: /opt/rocm/install
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Resolve latest tarball URL
+        id: resolve
+        env:
+          INPUT_URL: ${{ inputs.tarball_url }}
+        run: |
+          set -euo pipefail
+          INDEX_URL="${TARBALL_INDEX_URL:-}"
+          if [ -z "${INPUT_URL:-}" ] && [ -z "${INDEX_URL}" ]; then
+            echo "::error::No tarball index URL (set RVS_TARBALL_INDEX_URL) and no tarball_url input."
+            exit 1
+          fi
+          fetch_latest() {
+            local idx="$1"
+            local html raw name
+            html="$(curl -sSL --max-time 60 --retry 2 --retry-delay 2 "$idx" 2>/dev/null || true)"
+            raw="$(printf '%s' "$html" | grep -oE 'amdrocm[0-9]*-rvs-[0-9A-Za-z._\-]+-Linux\.tar\.gz' 2>/dev/null || true)"
+            name="$(printf '%s\n' "$raw" | sort -uV | tail -n 1 || true)"
+            [ -n "$name" ] || return 1
+            printf '%s/%s\n' "${idx%/}" "$name"
+          }
+          if [ -n "${INPUT_URL:-}" ]; then
+            URL="$INPUT_URL"
+          else
+            URL="$(fetch_latest "$INDEX_URL")"
+          fi
+          [ -n "${URL:-}" ] || { echo "::error::Could not resolve tarball URL"; exit 1; }
+          NAME="$(basename "$URL" | tr -d '\r\n')"
+          if [[ "$NAME" != *-Linux.tar.gz ]]; then
+            echo "::error::Docker nightly tests require a *-Linux.tar.gz relocatable tarball; got: ${NAME}" >&2
+            exit 1
+          fi
+          if [[ ! "$NAME" =~ -r[0-9]{4}\.[0-9]{8}-Linux\.tar\.gz$ ]]; then
+            echo "::error::Tar tarball must include -rMMmm.yyyymmdd- (e.g. -r0715.20260724-Linux.tar.gz); got: ${NAME}" >&2
+            exit 1
+          fi
+          {
+            echo "tarball_url<<RVS_NIGHTLY_TARBALL_URL"
+            printf '%s\n' "$URL"
+            echo "RVS_NIGHTLY_TARBALL_URL"
+            echo "tarball_name=$NAME"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "TARBALL_URL<<RVS_NIGHTLY_TARBALL_URL"
+            printf '%s\n' "$URL"
+            echo "RVS_NIGHTLY_TARBALL_URL"
+            echo "TARBALL_NAME=$NAME"
+          } >> "$GITHUB_ENV"
+          echo "Latest tarball : $NAME"
+
+      - name: Validate configuration and derive paths
+        id: prepare
+        env:
+          TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
+          INPUT_REMOTE_WORK_DIR: ${{ inputs.remote_work_dir || format('/tmp/rvs-nightly-docker-ubuntu22.04-{0}', github.run_id) }}
+          VAR_REMOTE_WORK_DIR: ${{ vars.RVS_REMOTE_WORK_DIR }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          chmod +x rvs_nightly_test.sh
+          if [ -z "${TARGET_NODE:-}" ]; then
+            echo "::error::No target node (set secrets.RVS_TARGET_NODE or workflow input target_node)." >&2
+            exit 1
+          fi
+          ./rvs_nightly_test.sh validate-config
+
+      - name: Setup SSH to target node
+        env:
+          REMOTE_WORK_DIR: ${{ steps.prepare.outputs.remote_work_dir }}
+        run: ./rvs_nightly_test.sh setup-ssh
+
+      - name: Export paths for remaining steps
+        env:
+          TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
+        run: |
+          {
+            echo "REMOTE_WORK_DIR=${{ steps.prepare.outputs.remote_work_dir }}"
+            echo "ROCM_MAJOR=${{ steps.prepare.outputs.rocm_major }}"
+            echo "INSTALL_DIR=${{ steps.prepare.outputs.install_dir }}"
+            echo "RVS_BIN=${{ steps.prepare.outputs.rvs_bin }}"
+          } >> "$GITHUB_ENV"
+          if [[ "$TARBALL_NAME" =~ -r([0-9]{2})([0-9]{2})\.([0-9]{8})-Linux\.tar\.gz$ ]]; then
+            echo "RVS_DOCKER_ROCM_VERSION=$((10#${BASH_REMATCH[1]})).$((10#${BASH_REMATCH[2]})).0a${BASH_REMATCH[3]}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Build ROCm docker image on build host
+        if: inputs.build_docker_image && inputs.build_on_target == false
+        env:
+          TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
+        run: |
+          chmod +x .github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
+          ./.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh --from-tarball "$TARBALL_NAME"
+
+      - name: Verify ROCm docker image on build host
+        if: inputs.build_docker_image && inputs.build_on_target == false
+        run: |
+          chmod +x rvs_nightly_docker.sh
+          ./rvs_nightly_docker.sh pull-image
+
+      - name: Ensure ROCm docker image on GPU target
+        env:
+          TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
+        run: |
+          chmod +x rvs_nightly_docker.sh
+          ./rvs_nightly_docker.sh ensure-image-on-target
+
+      - name: Verify ROCm in docker on target
+        run: ./rvs_nightly_docker.sh verify-rocm
+
+      - name: Install RVS in docker on target
+        run: ./rvs_nightly_docker.sh install-rvs
+
+  run-rvs-level-4-in-docker:
+    name: Run RVS level 4 in docker (Ubuntu 22.04) on target
+    needs: [install-rvs-in-docker]
+    runs-on: ${{ vars.RVS_NIGHTLY_DOCKER_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
+    timeout-minutes: 180
+    outputs:
+      rc:                   ${{ steps.level4.outputs.rc }}
+      start:                ${{ steps.level4.outputs.start }}
+      end:                  ${{ steps.level4.outputs.end }}
+      rvs_version:          ${{ steps.versions.outputs.rvs_version }}
+      target_rocm_version:  ${{ steps.versions.outputs.target_rocm_version }}
+    env:
+      TARGET_ROCM_PATH: /opt/rocm/install
+      TARGET_NODE:      ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
+      TARGET_USER:      ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
+      SSH_PRIVATE_KEY:  ${{ secrets.RVS_TARGET_SSH_KEY }}
+      RVS_DOCKER_ON_TARGET: 'true'
+      RVS_DOCKER_BUILD_DIR: .github/docker/rvs-nightly-rocm-ubuntu22.04
+      RVS_DOCKER_IMAGE_ARCHIVE: rvs-nightly-rocm-ubuntu22.04-image.tar.gz
+      REMOTE_WORK_DIR:  ${{ needs.install-rvs-in-docker.outputs.remote_work_dir }}
+      ROCM_MAJOR:       ${{ needs.install-rvs-in-docker.outputs.rocm_major }}
+      INSTALL_DIR:      ${{ needs.install-rvs-in-docker.outputs.install_dir }}
+      RVS_BIN:          ${{ needs.install-rvs-in-docker.outputs.rvs_bin }}
+      RVS_NIGHTLY_DOCKER_IMAGE: ${{ inputs.docker_image || vars.RVS_NIGHTLY_DOCKER_UBUNTU22_IMAGE || 'rvs-nightly-rocm-ubuntu22.04:latest' }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup SSH to target node
+        env:
+          REMOTE_WORK_DIR: ${{ needs.install-rvs-in-docker.outputs.remote_work_dir }}
+        run: |
+          chmod +x rvs_nightly_test.sh rvs_nightly_docker.sh
+          ./rvs_nightly_test.sh setup-ssh
+
+      - name: Run RVS level 4 in docker on target
+        id: level4
+        run: ./rvs_nightly_docker.sh run-level4
+
+      - name: Capture RVS and ROCm versions from docker on target
+        id: versions
+        if: always()
+        run: ./rvs_nightly_docker.sh capture-versions
+
+      - name: Collect logs from target
+        if: always()
+        run: ./rvs_nightly_test.sh collect-logs
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rvs-nightly-docker-ubuntu22.04-logs-${{ github.run_id }}
+          path: ./reports/
+          retention-days: 30
+          if-no-files-found: warn
+
+  create-test-report:
+    name: Create Test Report
+    needs: [install-rvs-in-docker, run-rvs-level-4-in-docker]
+    runs-on: ${{ vars.RUNNER_LABEL_UTILITY || 'ubuntu-latest' }}
+    if: always() && !cancelled() && needs.install-rvs-in-docker.result == 'success' && needs.run-rvs-level-4-in-docker.result != 'skipped'
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download test logs
+        uses: actions/download-artifact@v4
+        with:
+          name: rvs-nightly-docker-ubuntu22.04-logs-${{ github.run_id }}
+          path: ./reports
+        continue-on-error: true
+
+      - name: Build test report
+        id: report
+        env:
+          TARBALL_URL:          ${{ needs.install-rvs-in-docker.outputs.tarball_url }}
+          TARBALL_NAME:         ${{ needs.install-rvs-in-docker.outputs.tarball_name }}
+          TARGET_ROCM_PATH:     /opt/rocm/install
+          REMOTE_WORK_DIR:      ${{ needs.install-rvs-in-docker.outputs.remote_work_dir }}
+          RVS_BIN:              ${{ needs.install-rvs-in-docker.outputs.rvs_bin }}
+          RVS_LEVEL4_RC:        ${{ needs.run-rvs-level-4-in-docker.outputs.rc }}
+          RVS_LEVEL4_START:     ${{ needs.run-rvs-level-4-in-docker.outputs.start }}
+          RVS_LEVEL4_END:       ${{ needs.run-rvs-level-4-in-docker.outputs.end }}
+          RVS_VERSION:          ${{ needs.run-rvs-level-4-in-docker.outputs.rvs_version }}
+          TARGET_ROCM_VERSION:  ${{ needs.run-rvs-level-4-in-docker.outputs.target_rocm_version }}
+          GITHUB_RUN_ID:        ${{ github.run_id }}
+          GITHUB_SERVER_URL:    ${{ github.server_url }}
+          GITHUB_REPOSITORY:    ${{ github.repository }}
+          GITHUB_EVENT_NAME:    ${{ inputs.trigger_event || github.event_name }}
+        run: |
+          chmod +x rvs_nightly_test.sh
+          mkdir -p ./reports
+          ./rvs_nightly_test.sh build-report
+
+      - name: Upload report and logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rvs-nightly-docker-ubuntu22.04-report-${{ github.run_id }}
+          path: ./reports/
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Fail the workflow if level 4 failed
+        if: steps.report.outputs.overall == 'FAIL' || needs.run-rvs-level-4-in-docker.result == 'failure'
+        run: |
+          echo "::error::RVS docker (Ubuntu 22.04) test failure — level4 rc=${{ needs.run-rvs-level-4-in-docker.outputs.rc }}"
+          exit 1

--- a/.github/workflows/rvs-nightly-docker-ubuntu24.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu24.04-tests.yml
@@ -1,6 +1,6 @@
-name: RVS Nightly Tests (Docker)
+name: RVS Nightly Tests (Docker Ubuntu 24.04)
 
-# Deliver a ROCm-matched docker image to the GPU target, install RVS, run level 4 in docker.
+# Deliver a ROCm-matched docker image (ubuntu:24.04) to the GPU target, install RVS, run level 4 in docker.
 # ROCm SDK version is derived from the tar tarball name (-rMMmm.yyyymmdd-Linux.tar.gz).
 #
 # Default image delivery: build-on-target (docker build on the GPU node; no cross-host image transfer).
@@ -18,17 +18,27 @@ name: RVS Nightly Tests (Docker)
 # Prerequisites:
 # - Build host (self-hosted runner): curl/scp/ssh; HTTPS egress to tarball index; checkout supplies docker build context
 # - Target GPU node: docker, HTTPS to rocm.nightlies.amd.com, /dev/kfd, /dev/dri, SSH user in docker group
-# - ROCm SDK in docker image: therock-dist-linux-multiarch-<version>.tar.gz (default GPU_FAMILY=multiarch)
+# - ROCm SDK in docker image: therock-dist-linux-multiarch-<version>.tar.gz on ubuntu:24.04
 # - Secrets: RVS_TARGET_NODE, RVS_TARGET_SSH_KEY (optional RVS_TARGET_USER, RVS_TARBALL_INDEX_URL)
 # - Optional: vars.RVS_DOCKER_REGISTRY + secrets RVS_DOCKER_REGISTRY_USER/PASSWORD for registry mode
 #
 # See README_NIGHTLY_TESTS.md for SSH / tarball index configuration.
+#
+# Triggers
+# --------
+# - schedule: daily at 8:00 AM PST (16:00 UTC; PST is UTC-8)
+# - workflow_dispatch: manual run, or dispatched by Build Relocatable Packages
+#   after a successful push to main/master
+# - trigger_event input (push) is set by the package-build dispatch step
 
 on:
+  schedule:
+    # Run daily at 8:00 AM PST (16:00 UTC; PST is UTC-8)
+    - cron: '0 16 * * *'
   workflow_dispatch:
     inputs:
       trigger_event:
-        description: 'Label for report only (e.g. schedule or push); optional'
+        description: 'Package-build event that triggered this run (push); empty for manual or schedule runs'
         required: false
         default: ''
       tarball_url:
@@ -44,7 +54,7 @@ on:
         required: false
         default: ''
       docker_image:
-        description: 'ROCm runtime image (default: vars.RVS_NIGHTLY_DOCKER_IMAGE or rvs-nightly-rocm:latest)'
+        description: 'ROCm runtime image (default: vars.RVS_NIGHTLY_DOCKER_UBUNTU24_IMAGE or vars.RVS_NIGHTLY_DOCKER_IMAGE or rvs-nightly-rocm:latest)'
         required: false
         default: ''
       build_docker_image:
@@ -62,7 +72,7 @@ on:
         required: false
         default: 'auto'
       remote_work_dir:
-        description: 'Work dir on target (default: /tmp/rvs-nightly-docker-<run_id>)'
+        description: 'Work dir on target (default: /tmp/rvs-nightly-docker-ubuntu24.04-<run_id>)'
         required: false
         default: ''
 
@@ -70,12 +80,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: rvs-nightly-docker-${{ github.workflow }}
+  group: rvs-nightly-docker-ubuntu24.04-${{ github.workflow }}
   cancel-in-progress: false
 
 env:
   TARBALL_INDEX_URL: ${{ secrets.RVS_TARBALL_INDEX_URL }}
-  RVS_NIGHTLY_DOCKER_IMAGE: ${{ inputs.docker_image || vars.RVS_NIGHTLY_DOCKER_IMAGE || 'rvs-nightly-rocm:latest' }}
+  RVS_NIGHTLY_DOCKER_IMAGE: ${{ inputs.docker_image || vars.RVS_NIGHTLY_DOCKER_UBUNTU24_IMAGE || vars.RVS_NIGHTLY_DOCKER_IMAGE || 'rvs-nightly-rocm:latest' }}
+  RVS_DOCKER_BUILD_DIR: .github/docker/rvs-nightly-rocm
+  RVS_DOCKER_IMAGE_ARCHIVE: rvs-nightly-rocm-ubuntu24.04-image.tar.gz
   RVS_DOCKER_ON_TARGET: 'true'
   RVS_DOCKER_TRANSFER_MODE: ${{ inputs.docker_transfer_mode || vars.RVS_DOCKER_TRANSFER_MODE || 'auto' }}
   RVS_DOCKER_BUILD_ON_TARGET: ${{ (inputs.build_on_target != false) && (vars.RVS_DOCKER_BUILD_ON_TARGET != 'false') && 'true' || 'false' }}
@@ -90,7 +102,7 @@ env:
 
 jobs:
   install-rvs-in-docker:
-    name: Ensure ROCm image on target and install RVS in docker
+    name: Ensure ROCm image (Ubuntu 24.04) on target and install RVS in docker
     runs-on: ${{ vars.RVS_NIGHTLY_DOCKER_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
     timeout-minutes: 180
     outputs:
@@ -159,7 +171,7 @@ jobs:
         id: prepare
         env:
           TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
-          INPUT_REMOTE_WORK_DIR: ${{ inputs.remote_work_dir || format('/tmp/rvs-nightly-docker-{0}', github.run_id) }}
+          INPUT_REMOTE_WORK_DIR: ${{ inputs.remote_work_dir || format('/tmp/rvs-nightly-docker-ubuntu24.04-{0}', github.run_id) }}
           VAR_REMOTE_WORK_DIR: ${{ vars.RVS_REMOTE_WORK_DIR }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
@@ -217,7 +229,7 @@ jobs:
         run: ./rvs_nightly_docker.sh install-rvs
 
   run-rvs-level-4-in-docker:
-    name: Run RVS level 4 in docker on target
+    name: Run RVS level 4 in docker (Ubuntu 24.04) on target
     needs: [install-rvs-in-docker]
     runs-on: ${{ vars.RVS_NIGHTLY_DOCKER_RUNNER_LABEL || vars.RVS_TEST_RUNNER_LABEL || 'self-hosted' }}
     timeout-minutes: 180
@@ -233,11 +245,13 @@ jobs:
       TARGET_USER:      ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
       SSH_PRIVATE_KEY:  ${{ secrets.RVS_TARGET_SSH_KEY }}
       RVS_DOCKER_ON_TARGET: 'true'
+      RVS_DOCKER_BUILD_DIR: .github/docker/rvs-nightly-rocm
+      RVS_DOCKER_IMAGE_ARCHIVE: rvs-nightly-rocm-ubuntu24.04-image.tar.gz
       REMOTE_WORK_DIR:  ${{ needs.install-rvs-in-docker.outputs.remote_work_dir }}
       ROCM_MAJOR:       ${{ needs.install-rvs-in-docker.outputs.rocm_major }}
       INSTALL_DIR:      ${{ needs.install-rvs-in-docker.outputs.install_dir }}
       RVS_BIN:          ${{ needs.install-rvs-in-docker.outputs.rvs_bin }}
-      RVS_NIGHTLY_DOCKER_IMAGE: ${{ inputs.docker_image || vars.RVS_NIGHTLY_DOCKER_IMAGE || 'rvs-nightly-rocm:latest' }}
+      RVS_NIGHTLY_DOCKER_IMAGE: ${{ inputs.docker_image || vars.RVS_NIGHTLY_DOCKER_UBUNTU24_IMAGE || vars.RVS_NIGHTLY_DOCKER_IMAGE || 'rvs-nightly-rocm:latest' }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -266,7 +280,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: rvs-nightly-docker-logs-${{ github.run_id }}
+          name: rvs-nightly-docker-ubuntu24.04-logs-${{ github.run_id }}
           path: ./reports/
           retention-days: 30
           if-no-files-found: warn
@@ -283,7 +297,7 @@ jobs:
       - name: Download test logs
         uses: actions/download-artifact@v4
         with:
-          name: rvs-nightly-docker-logs-${{ github.run_id }}
+          name: rvs-nightly-docker-ubuntu24.04-logs-${{ github.run_id }}
           path: ./reports
         continue-on-error: true
 
@@ -313,7 +327,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: rvs-nightly-docker-report-${{ github.run_id }}
+          name: rvs-nightly-docker-ubuntu24.04-report-${{ github.run_id }}
           path: ./reports/
           retention-days: 30
           if-no-files-found: warn
@@ -321,5 +335,5 @@ jobs:
       - name: Fail the workflow if level 4 failed
         if: steps.report.outputs.overall == 'FAIL' || needs.run-rvs-level-4-in-docker.result == 'failure'
         run: |
-          echo "::error::RVS docker test failure — level4 rc=${{ needs.run-rvs-level-4-in-docker.outputs.rc }}"
+          echo "::error::RVS docker (Ubuntu 24.04) test failure — level4 rc=${{ needs.run-rvs-level-4-in-docker.outputs.rc }}"
           exit 1

--- a/rvs_nightly_docker.sh
+++ b/rvs_nightly_docker.sh
@@ -21,7 +21,10 @@ set -euo pipefail
 DOCKER_IMAGE="${RVS_NIGHTLY_DOCKER_IMAGE:-rvs-nightly-rocm:latest}"
 DOCKER_IMAGE_ARCHIVE="${RVS_DOCKER_IMAGE_ARCHIVE:-rvs-nightly-rocm-image.tar.gz}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-DOCKER_BUILD_DIR="${REPO_ROOT}/.github/docker/rvs-nightly-rocm"
+DOCKER_BUILD_DIR="${RVS_DOCKER_BUILD_DIR:-${REPO_ROOT}/.github/docker/rvs-nightly-rocm}"
+if [[ "$DOCKER_BUILD_DIR" != /* ]]; then
+  DOCKER_BUILD_DIR="${REPO_ROOT}/${DOCKER_BUILD_DIR#./}"
+fi
 
 usage() {
   cat <<'EOF'
@@ -49,6 +52,7 @@ Environment:
   RVS_DOCKER_REGISTRY_PASSWORD optional registry login password
   RVS_DOCKER_ROCM_VERSION    expected ROCm SDK version (for skip-if-present matching)
   RVS_DOCKER_SKIP_IF_PRESENT true (default) skips transfer when target already has image
+  RVS_DOCKER_BUILD_DIR         docker build context (default: .github/docker/rvs-nightly-rocm)
 EOF
 }
 


### PR DESCRIPTION
Renamed the 24.04 workflow to rvs-nightly-docker-ubuntu24.04-tests.yml and added a parallel Ubuntu 22.04 docker context/workflow (rvs-nightly-rocm-ubuntu22.04 image + rvs-nightly-docker-ubuntu22.04-tests.yml).