### PR TITLE
Docker nightly CI fix

### DIFF
--- a/.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
@@ -6,6 +6,7 @@
 #   ./build-rocm-image.sh --channel nightly --gpu-family multiarch
 #   ./build-rocm-image.sh --rocm-version 10.1.0a20260819 --gpu-family multiarch
 #   ./build-rocm-image.sh --from-tarball amdrocm10-rvs-1.7.10-r1001.20260819-Linux.tar.gz
+#   ./build-rocm-image.sh --from-tarball ... --fallback-latest-sdk
 #   ./build-rocm-image.sh --channel nightly --tag rvs-nightly-rocm-ubuntu22.04:latest
 
 set -euo pipefail
@@ -20,6 +21,7 @@ CHANNEL="nightly"
 IMAGE_TAG=""
 ROCM_SDK_BASE_URL=""
 FROM_TARBALL=""
+FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}"
 
 NIGHTLY_INDEX="${ROCM_SDK_NIGHTLY_INDEX_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch/}"
 NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch}"
@@ -41,6 +43,22 @@ resolve_sdk_base() {
     echo "::error::Unrecognized ROCm version format: $ver" >&2
     exit 1
   fi
+}
+
+fallback_latest_sdk_enabled() {
+  case "${FALLBACK_LATEST_SDK}" in
+    true|1|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fetch_latest_nightly_sdk_for_line() {
+  local listing="$1"
+  local major="$2"
+  local minor="$3"
+  local prefix="${major}.${minor}.0a"
+  grep -oE "therock-dist-linux-${GPU_FAMILY}-${prefix}[0-9]+" "$listing" \
+    | sed "s|^therock-dist-linux-${GPU_FAMILY}-||" | sort -V | tail -1
 }
 
 fetch_latest_version() {
@@ -97,14 +115,24 @@ resolve_rocm_from_tarball() {
     sdk_file="therock-dist-linux-${GPU_FAMILY}-${exact}.tar.gz"
     listing_tmp="$(mktemp)"
     wget -q -O "$listing_tmp" "$NIGHTLY_INDEX"
-    if ! grep -qF "$sdk_file" "$listing_tmp"; then
+    if grep -qF "$sdk_file" "$listing_tmp"; then
+      ROCM_VERSION="$exact"
+      ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+    elif fallback_latest_sdk_enabled; then
+      ROCM_VERSION="$(fetch_latest_nightly_sdk_for_line "$listing_tmp" "$major" "$minor")"
+      if [ -z "$ROCM_VERSION" ]; then
+        rm -f "$listing_tmp"
+        echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX}) and no ${major}.${minor}.0a* fallback on listing" >&2
+        exit 1
+      fi
+      echo "::warning::Exact SDK ${exact} missing for ${base}; using latest available ${ROCM_VERSION} (--fallback-latest-sdk)" >&2
+      ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+    else
       rm -f "$listing_tmp"
-      echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX})" >&2
+      echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX}). Pass --fallback-latest-sdk or set RVS_DOCKER_SDK_FALLBACK_LATEST=true to use the latest ${major}.${minor}.0a* build." >&2
       exit 1
     fi
     rm -f "$listing_tmp"
-    ROCM_VERSION="$exact"
-    ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
   fi
 
   if [ -z "$ROCM_VERSION" ]; then
@@ -121,6 +149,7 @@ while [ $# -gt 0 ]; do
     --gpu-family)   GPU_FAMILY="$2"; shift 2 ;;
     --channel)      CHANNEL="$2"; shift 2 ;;
     --tag)          IMAGE_TAG="$2"; shift 2 ;;
+    --fallback-latest-sdk) FALLBACK_LATEST_SDK=true; shift ;;
     -h|--help)      usage ;;
     *) echo "Unknown arg: $1" >&2; usage ;;
   esac

--- a/.github/docker/rvs-nightly-rocm-ubuntu26.04/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm-ubuntu26.04/build-rocm-image.sh
@@ -6,6 +6,7 @@
 #   ./build-rocm-image.sh --channel nightly --gpu-family multiarch
 #   ./build-rocm-image.sh --rocm-version 10.1.0a20260819 --gpu-family multiarch
 #   ./build-rocm-image.sh --from-tarball amdrocm10-rvs-1.7.10-r1001.20260819-Linux.tar.gz
+#   ./build-rocm-image.sh --from-tarball ... --fallback-latest-sdk
 #   ./build-rocm-image.sh --channel nightly --tag rvs-nightly-rocm-ubuntu26.04:latest
 
 set -euo pipefail
@@ -20,6 +21,7 @@ CHANNEL="nightly"
 IMAGE_TAG=""
 ROCM_SDK_BASE_URL=""
 FROM_TARBALL=""
+FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}"
 
 NIGHTLY_INDEX="${ROCM_SDK_NIGHTLY_INDEX_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch/}"
 NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch}"
@@ -41,6 +43,22 @@ resolve_sdk_base() {
     echo "::error::Unrecognized ROCm version format: $ver" >&2
     exit 1
   fi
+}
+
+fallback_latest_sdk_enabled() {
+  case "${FALLBACK_LATEST_SDK}" in
+    true|1|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fetch_latest_nightly_sdk_for_line() {
+  local listing="$1"
+  local major="$2"
+  local minor="$3"
+  local prefix="${major}.${minor}.0a"
+  grep -oE "therock-dist-linux-${GPU_FAMILY}-${prefix}[0-9]+" "$listing" \
+    | sed "s|^therock-dist-linux-${GPU_FAMILY}-||" | sort -V | tail -1
 }
 
 fetch_latest_version() {
@@ -97,14 +115,24 @@ resolve_rocm_from_tarball() {
     sdk_file="therock-dist-linux-${GPU_FAMILY}-${exact}.tar.gz"
     listing_tmp="$(mktemp)"
     wget -q -O "$listing_tmp" "$NIGHTLY_INDEX"
-    if ! grep -qF "$sdk_file" "$listing_tmp"; then
+    if grep -qF "$sdk_file" "$listing_tmp"; then
+      ROCM_VERSION="$exact"
+      ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+    elif fallback_latest_sdk_enabled; then
+      ROCM_VERSION="$(fetch_latest_nightly_sdk_for_line "$listing_tmp" "$major" "$minor")"
+      if [ -z "$ROCM_VERSION" ]; then
+        rm -f "$listing_tmp"
+        echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX}) and no ${major}.${minor}.0a* fallback on listing" >&2
+        exit 1
+      fi
+      echo "::warning::Exact SDK ${exact} missing for ${base}; using latest available ${ROCM_VERSION} (--fallback-latest-sdk)" >&2
+      ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+    else
       rm -f "$listing_tmp"
-      echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX})" >&2
+      echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX}). Pass --fallback-latest-sdk or set RVS_DOCKER_SDK_FALLBACK_LATEST=true to use the latest ${major}.${minor}.0a* build." >&2
       exit 1
     fi
     rm -f "$listing_tmp"
-    ROCM_VERSION="$exact"
-    ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
   fi
 
   if [ -z "$ROCM_VERSION" ]; then
@@ -121,6 +149,7 @@ while [ $# -gt 0 ]; do
     --gpu-family)   GPU_FAMILY="$2"; shift 2 ;;
     --channel)      CHANNEL="$2"; shift 2 ;;
     --tag)          IMAGE_TAG="$2"; shift 2 ;;
+    --fallback-latest-sdk) FALLBACK_LATEST_SDK=true; shift ;;
     -h|--help)      usage ;;
     *) echo "Unknown arg: $1" >&2; usage ;;
   esac

--- a/.github/docker/rvs-nightly-rocm/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm/build-rocm-image.sh
@@ -7,6 +7,8 @@
 #   ./build-rocm-image.sh --rocm-version 10.1.0a20260819 --gpu-family multiarch
 #   ./build-rocm-image.sh --from-tarball amdrocm7-rvs-1.4.21-r0714.20260724-Linux.tar.gz
 #       (requires *-Linux.tar.gz with -rMMmm.yyyymmdd-; nightly pins exact 7.14.0a20260724 SDK)
+#   ./build-rocm-image.sh --from-tarball ... --fallback-latest-sdk
+#       (if exact SDK date missing on CDN, use latest 7.14.0a* for same ROCm line)
 #   ./build-rocm-image.sh --channel nightly --tag rvs-nightly-rocm:latest
 
 set -euo pipefail
@@ -19,6 +21,7 @@ CHANNEL="nightly"
 IMAGE_TAG=""
 ROCM_SDK_BASE_URL=""
 FROM_TARBALL=""
+FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}"
 
 NIGHTLY_INDEX="${ROCM_SDK_NIGHTLY_INDEX_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch/}"
 NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch}"
@@ -40,6 +43,22 @@ resolve_sdk_base() {
     echo "::error::Unrecognized ROCm version format: $ver" >&2
     exit 1
   fi
+}
+
+fallback_latest_sdk_enabled() {
+  case "${FALLBACK_LATEST_SDK}" in
+    true|1|yes|YES) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+fetch_latest_nightly_sdk_for_line() {
+  local listing="$1"
+  local major="$2"
+  local minor="$3"
+  local prefix="${major}.${minor}.0a"
+  grep -oE "therock-dist-linux-${GPU_FAMILY}-${prefix}[0-9]+" "$listing" \
+    | sed "s|^therock-dist-linux-${GPU_FAMILY}-||" | sort -V | tail -1
 }
 
 fetch_latest_version() {
@@ -98,14 +117,24 @@ resolve_rocm_from_tarball() {
     sdk_file="therock-dist-linux-${GPU_FAMILY}-${exact}.tar.gz"
     listing_tmp="$(mktemp)"
     wget -q -O "$listing_tmp" "$NIGHTLY_INDEX"
-    if ! grep -qF "$sdk_file" "$listing_tmp"; then
+    if grep -qF "$sdk_file" "$listing_tmp"; then
+      ROCM_VERSION="$exact"
+      ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+    elif fallback_latest_sdk_enabled; then
+      ROCM_VERSION="$(fetch_latest_nightly_sdk_for_line "$listing_tmp" "$major" "$minor")"
+      if [ -z "$ROCM_VERSION" ]; then
+        rm -f "$listing_tmp"
+        echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX}) and no ${major}.${minor}.0a* fallback on listing" >&2
+        exit 1
+      fi
+      echo "::warning::Exact SDK ${exact} missing for ${base}; using latest available ${ROCM_VERSION} (--fallback-latest-sdk)" >&2
+      ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
+    else
       rm -f "$listing_tmp"
-      echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX})" >&2
+      echo "::error::No multiarch SDK ${exact} for tar ${base} (missing ${sdk_file} on ${NIGHTLY_INDEX}). Pass --fallback-latest-sdk or set RVS_DOCKER_SDK_FALLBACK_LATEST=true to use the latest ${major}.${minor}.0a* build." >&2
       exit 1
     fi
     rm -f "$listing_tmp"
-    ROCM_VERSION="$exact"
-    ROCM_SDK_BASE_URL="$NIGHTLY_BASE"
   fi
 
   if [ -z "$ROCM_VERSION" ]; then
@@ -122,6 +151,7 @@ while [ $# -gt 0 ]; do
     --gpu-family)   GPU_FAMILY="$2"; shift 2 ;;
     --channel)      CHANNEL="$2"; shift 2 ;;
     --tag)          IMAGE_TAG="$2"; shift 2 ;;
+    --fallback-latest-sdk) FALLBACK_LATEST_SDK=true; shift ;;
     -h|--help)      usage ;;
     *) echo "Unknown arg: $1" >&2; usage ;;
   esac

--- a/.github/workflows/rvs-nightly-docker-ubuntu22.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu22.04-tests.yml
@@ -65,6 +65,11 @@ on:
         description: 'Work dir on target (default: /tmp/rvs-nightly-docker-ubuntu22.04-<run_id>)'
         required: false
         default: ''
+      fallback_latest_sdk:
+        description: 'If exact multiarch SDK date is missing on CDN, use latest same ROCm line (10.x.0a*)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -85,6 +90,7 @@ env:
   RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
   RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
   RVS_DOCKER_SKIP_IF_PRESENT: 'true'
+  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (inputs.fallback_latest_sdk == false || vars.RVS_DOCKER_SDK_FALLBACK_LATEST == 'false') && 'false' || 'true' }}
   TARGET_ROCM_PATH: /opt/rocm/install
   TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
   TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
@@ -197,7 +203,11 @@ jobs:
           TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
         run: |
           chmod +x .github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
-          ./.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh --from-tarball "$TARBALL_NAME"
+          fallback_args=()
+          if [ "${RVS_DOCKER_SDK_FALLBACK_LATEST}" = true ]; then
+            fallback_args=(--fallback-latest-sdk)
+          fi
+          ./.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh --from-tarball "$TARBALL_NAME" "${fallback_args[@]}"
 
       - name: Verify ROCm docker image on build host
         if: inputs.build_docker_image && inputs.build_on_target == false

--- a/.github/workflows/rvs-nightly-docker-ubuntu24.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu24.04-tests.yml
@@ -75,6 +75,11 @@ on:
         description: 'Work dir on target (default: /tmp/rvs-nightly-docker-ubuntu24.04-<run_id>)'
         required: false
         default: ''
+      fallback_latest_sdk:
+        description: 'If exact multiarch SDK date is missing on CDN, use latest same ROCm line (10.x.0a*)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -95,6 +100,7 @@ env:
   RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
   RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
   RVS_DOCKER_SKIP_IF_PRESENT: 'true'
+  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (inputs.fallback_latest_sdk == false || vars.RVS_DOCKER_SDK_FALLBACK_LATEST == 'false') && 'false' || 'true' }}
   TARGET_ROCM_PATH: /opt/rocm/install
   TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
   TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
@@ -207,7 +213,11 @@ jobs:
           TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
         run: |
           chmod +x .github/docker/rvs-nightly-rocm/build-rocm-image.sh
-          ./.github/docker/rvs-nightly-rocm/build-rocm-image.sh --from-tarball "$TARBALL_NAME"
+          fallback_args=()
+          if [ "${RVS_DOCKER_SDK_FALLBACK_LATEST}" = true ]; then
+            fallback_args=(--fallback-latest-sdk)
+          fi
+          ./.github/docker/rvs-nightly-rocm/build-rocm-image.sh --from-tarball "$TARBALL_NAME" "${fallback_args[@]}"
 
       - name: Verify ROCm docker image on build host
         if: inputs.build_docker_image && inputs.build_on_target == false

--- a/.github/workflows/rvs-nightly-docker-ubuntu26.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu26.04-tests.yml
@@ -65,6 +65,11 @@ on:
         description: 'Work dir on target (default: /tmp/rvs-nightly-docker-ubuntu26.04-<run_id>)'
         required: false
         default: ''
+      fallback_latest_sdk:
+        description: 'If exact multiarch SDK date is missing on CDN, use latest same ROCm line (10.x.0a*)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -85,6 +90,7 @@ env:
   RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
   RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
   RVS_DOCKER_SKIP_IF_PRESENT: 'true'
+  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (inputs.fallback_latest_sdk == false || vars.RVS_DOCKER_SDK_FALLBACK_LATEST == 'false') && 'false' || 'true' }}
   TARGET_ROCM_PATH: /opt/rocm/install
   TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
   TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}
@@ -197,7 +203,11 @@ jobs:
           TARBALL_NAME: ${{ steps.resolve.outputs.tarball_name }}
         run: |
           chmod +x .github/docker/rvs-nightly-rocm-ubuntu26.04/build-rocm-image.sh
-          ./.github/docker/rvs-nightly-rocm-ubuntu26.04/build-rocm-image.sh --from-tarball "$TARBALL_NAME"
+          fallback_args=()
+          if [ "${RVS_DOCKER_SDK_FALLBACK_LATEST}" = true ]; then
+            fallback_args=(--fallback-latest-sdk)
+          fi
+          ./.github/docker/rvs-nightly-rocm-ubuntu26.04/build-rocm-image.sh --from-tarball "$TARBALL_NAME" "${fallback_args[@]}"
 
       - name: Verify ROCm docker image on build host
         if: inputs.build_docker_image && inputs.build_on_target == false

--- a/rvs_nightly_docker.sh
+++ b/rvs_nightly_docker.sh
@@ -53,7 +53,15 @@ Environment:
   RVS_DOCKER_ROCM_VERSION    expected ROCm SDK version (for skip-if-present matching)
   RVS_DOCKER_SKIP_IF_PRESENT true (default) skips transfer when target already has image
   RVS_DOCKER_BUILD_DIR         docker build context (default: .github/docker/rvs-nightly-rocm)
+  RVS_DOCKER_SDK_FALLBACK_LATEST  when true, use latest same-line SDK if exact date missing on CDN
 EOF
+}
+
+docker_build_fallback_args() {
+  case "${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}" in
+    true|1|yes|YES) printf '%s' ' --fallback-latest-sdk' ;;
+    *) printf '%s' '' ;;
+  esac
 }
 
 require_env() {
@@ -384,10 +392,12 @@ cmd_build_image_on_target() {
   phase_end "Sync docker build context to target"
 
   phase_start "docker build on GPU target"
+  local fallback_args
+  fallback_args="$(docker_build_fallback_args)"
   ssh -q -F "$SSH_CONFIG_FILE" rvs-target bash -s <<REMOTE
 set -euo pipefail
 chmod +x '${remote_build_dir}/build-rocm-image.sh'
-'${remote_build_dir}/build-rocm-image.sh' --from-tarball '${TARBALL_NAME}'
+'${remote_build_dir}/build-rocm-image.sh' --from-tarball '${TARBALL_NAME}'${fallback_args}
 REMOTE
   phase_end "docker build on GPU target"
   cmd_verify_image_on_target


### PR DESCRIPTION
SDK fallback: When the exact multiarch SDK date from the RVS tar isn’t on the CDN yet, --fallback-latest-sdk / fallback_latest_sdk (default on) uses the latest same-line 10.x.0a* build instead of failing.