### PR TITLE
Docker nightly CI fix

### DIFF
--- a/.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm-ubuntu22.04/build-rocm-image.sh
@@ -21,7 +21,7 @@ CHANNEL="nightly"
 IMAGE_TAG=""
 ROCM_SDK_BASE_URL=""
 FROM_TARBALL=""
-FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}"
+FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-true}"
 
 NIGHTLY_INDEX="${ROCM_SDK_NIGHTLY_INDEX_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch/}"
 NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch}"

--- a/.github/docker/rvs-nightly-rocm-ubuntu26.04/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm-ubuntu26.04/build-rocm-image.sh
@@ -21,7 +21,7 @@ CHANNEL="nightly"
 IMAGE_TAG=""
 ROCM_SDK_BASE_URL=""
 FROM_TARBALL=""
-FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}"
+FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-true}"
 
 NIGHTLY_INDEX="${ROCM_SDK_NIGHTLY_INDEX_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch/}"
 NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch}"

--- a/.github/docker/rvs-nightly-rocm/build-rocm-image.sh
+++ b/.github/docker/rvs-nightly-rocm/build-rocm-image.sh
@@ -21,7 +21,7 @@ CHANNEL="nightly"
 IMAGE_TAG=""
 ROCM_SDK_BASE_URL=""
 FROM_TARBALL=""
-FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}"
+FALLBACK_LATEST_SDK="${RVS_DOCKER_SDK_FALLBACK_LATEST:-true}"
 
 NIGHTLY_INDEX="${ROCM_SDK_NIGHTLY_INDEX_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch/}"
 NIGHTLY_BASE="${ROCM_SDK_NIGHTLY_BASE_URL:-https://rocm.nightlies.amd.com/tarball-multi-arch}"

--- a/.github/workflows/rvs-nightly-docker-ubuntu22.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu22.04-tests.yml
@@ -90,7 +90,9 @@ env:
   RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
   RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
   RVS_DOCKER_SKIP_IF_PRESENT: 'true'
-  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (inputs.fallback_latest_sdk == false || vars.RVS_DOCKER_SDK_FALLBACK_LATEST == 'false') && 'false' || 'true' }}
+  # Default true on schedule (inputs unset). github.event.inputs is a string; empty != 'false'.
+  # Opt out: uncheck workflow_dispatch fallback_latest_sdk, or set vars.RVS_DOCKER_SDK_FALLBACK_LATEST=false
+  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (github.event.inputs.fallback_latest_sdk != 'false' && vars.RVS_DOCKER_SDK_FALLBACK_LATEST != 'false') && 'true' || 'false' }}
   TARGET_ROCM_PATH: /opt/rocm/install
   TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
   TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}

--- a/.github/workflows/rvs-nightly-docker-ubuntu24.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu24.04-tests.yml
@@ -100,7 +100,9 @@ env:
   RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
   RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
   RVS_DOCKER_SKIP_IF_PRESENT: 'true'
-  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (inputs.fallback_latest_sdk == false || vars.RVS_DOCKER_SDK_FALLBACK_LATEST == 'false') && 'false' || 'true' }}
+  # Default true on schedule (inputs unset). github.event.inputs is a string; empty != 'false'.
+  # Opt out: uncheck workflow_dispatch fallback_latest_sdk, or set vars.RVS_DOCKER_SDK_FALLBACK_LATEST=false
+  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (github.event.inputs.fallback_latest_sdk != 'false' && vars.RVS_DOCKER_SDK_FALLBACK_LATEST != 'false') && 'true' || 'false' }}
   TARGET_ROCM_PATH: /opt/rocm/install
   TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
   TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}

--- a/.github/workflows/rvs-nightly-docker-ubuntu26.04-tests.yml
+++ b/.github/workflows/rvs-nightly-docker-ubuntu26.04-tests.yml
@@ -90,7 +90,9 @@ env:
   RVS_DOCKER_REGISTRY_USER: ${{ secrets.RVS_DOCKER_REGISTRY_USER }}
   RVS_DOCKER_REGISTRY_PASSWORD: ${{ secrets.RVS_DOCKER_REGISTRY_PASSWORD }}
   RVS_DOCKER_SKIP_IF_PRESENT: 'true'
-  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (inputs.fallback_latest_sdk == false || vars.RVS_DOCKER_SDK_FALLBACK_LATEST == 'false') && 'false' || 'true' }}
+  # Default true on schedule (inputs unset). github.event.inputs is a string; empty != 'false'.
+  # Opt out: uncheck workflow_dispatch fallback_latest_sdk, or set vars.RVS_DOCKER_SDK_FALLBACK_LATEST=false
+  RVS_DOCKER_SDK_FALLBACK_LATEST: ${{ (github.event.inputs.fallback_latest_sdk != 'false' && vars.RVS_DOCKER_SDK_FALLBACK_LATEST != 'false') && 'true' || 'false' }}
   TARGET_ROCM_PATH: /opt/rocm/install
   TARGET_NODE: ${{ inputs.target_node || secrets.RVS_TARGET_NODE }}
   TARGET_USER: ${{ inputs.target_user || secrets.RVS_TARGET_USER }}

--- a/rvs_nightly_docker.sh
+++ b/rvs_nightly_docker.sh
@@ -53,12 +53,12 @@ Environment:
   RVS_DOCKER_ROCM_VERSION    expected ROCm SDK version (for skip-if-present matching)
   RVS_DOCKER_SKIP_IF_PRESENT true (default) skips transfer when target already has image
   RVS_DOCKER_BUILD_DIR         docker build context (default: .github/docker/rvs-nightly-rocm)
-  RVS_DOCKER_SDK_FALLBACK_LATEST  when true, use latest same-line SDK if exact date missing on CDN
+  RVS_DOCKER_SDK_FALLBACK_LATEST  when true (default), use latest same-line SDK if exact date missing on CDN
 EOF
 }
 
 docker_build_fallback_args() {
-  case "${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}" in
+  case "${RVS_DOCKER_SDK_FALLBACK_LATEST:-true}" in
     true|1|yes|YES) printf '%s' ' --fallback-latest-sdk' ;;
     *) printf '%s' '' ;;
   esac
@@ -214,7 +214,7 @@ cmd_build_image_on_build_host() {
   fi
   chmod +x "$build_script"
   local fallback_args=()
-  case "${RVS_DOCKER_SDK_FALLBACK_LATEST:-false}" in
+  case "${RVS_DOCKER_SDK_FALLBACK_LATEST:-true}" in
     true|1|yes|YES) fallback_args=(--fallback-latest-sdk) ;;
   esac
   phase_start "docker build on build host"


### PR DESCRIPTION
 For the nightly docker jobs, if the exact SDK for the RVS tarball date is missing on the CDN, the build will use the latest listed SDK on the same ROCm line