### PR TITLE
 keep canonical path only in RPATH

### DIFF
--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -122,14 +122,15 @@ GitHub Actions Workflow
 
 ### Key Technical Details
 
-**Relocatable RPATH**: The canonical list lives in **[`cmake_modules/RVSPackagedRpath.cmake`](../cmake_modules/RVSPackagedRpath.cmake)** (host triple detection via `amdclang++ --print-target-triple` is done there) and is applied via **`CMAKE_INSTALL_RPATH`** / **`CMAKE_BUILD_RPATH`** in **`CMakeLists.txt`**. **`CMAKE_*_LINKER_FLAGS_INIT`** only adds **`--enable-new-dtags`** (RUNPATH behavior). **Local dev builds** may also retain implicit **`$ROCM_PATH`** link-dir RUNPATH entries ( **`CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH`** is set only when **`GITHUB_ACTIONS=true`** ).
+**Relocatable RPATH**: The canonical list lives in **[`cmake_modules/RVSPackagedRpath.cmake`](../../cmake_modules/RVSPackagedRpath.cmake)** (host triple detection via `amdclang++ --print-target-triple` is done there) and is applied via **`CMAKE_INSTALL_RPATH`** / **`CMAKE_BUILD_RPATH`** in **`CMakeLists.txt`**. **`CMAKE_*_LINKER_FLAGS_INIT`** only adds **`--enable-new-dtags`** (RUNPATH behavior). **Local dev builds** may also retain implicit **`$ROCM_PATH`** link-dir RUNPATH entries ( **`CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH`** is set only when **`GITHUB_ACTIONS=true`** ).
 
-**Packaged artifacts** (DEB/RPM/TGZ): **`CPACK_PRE_BUILD_SCRIPTS`** runs **[`cmake_modules/cpack-patch-rpath.cmake.in`](../cmake_modules/cpack-patch-rpath.cmake.in)** before CPack seals the package. It uses **`patchelf`** to replace RUNPATH on every staged ELF with the canonical list (no build-machine SDK paths). Requires **`patchelf`** on the packaging host (`build_packages_local.sh` installs it).
+**Packaged artifacts** (DEB/RPM/TGZ): **`CPACK_PRE_BUILD_SCRIPTS`** runs **[`cmake_modules/cpack-patch-rpath.cmake.in`](../../cmake_modules/cpack-patch-rpath.cmake.in)** before CPack seals the package. It uses **`patchelf`** to replace RUNPATH on every staged ELF with the canonical list (no build-machine SDK paths). Requires **`patchelf`** on the packaging host (`build_packages_local.sh` installs it).
 
 The **`$ORIGIN`** relative entries resolve to the install prefix (`.../extras-<N>/bin` → `.../extras-<N>/lib`). Absolute paths add **`/opt/rocm/lib`**, **`/opt/rocm/lib/llvm/lib`**, **`/opt/rocm/core-<ROCM_MAJOR>/lib`**, **`/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib`**, and per-host-triple **`libomp`** dirs when the triple is known — equivalent to:
 
 ```bash
-$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-<ROCM_MAJOR>/lib:/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib
+# Example for ROCm major 10 (per-triple libomp dirs omitted)
+CMAKE_INSTALL_RPATH='$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-10/lib:/opt/rocm/core-10/lib/llvm/lib'
 ```
 
 **Automatic Version Management**: CMake reads the project version from `CMakeLists.txt` and CPack uses it for package naming automatically. The **patch version** is auto-computed at CMake configure time: `git describe --tags --match "v<major>.<minor>.*"` counts commits since the last matching `v` tag. For example, if the tag is `v1.3.0` and there have been 15 commits since, the package version becomes `1.3.15`. If no matching tag exists or git is unavailable, the patch defaults to `0` from `CMakeLists.txt`. This works for both CI builds and direct local `cmake` invocations.

--- a/.github/workflows/README_BUILD_PACKAGES.md
+++ b/.github/workflows/README_BUILD_PACKAGES.md
@@ -122,10 +122,14 @@ GitHub Actions Workflow
 
 ### Key Technical Details
 
-**Relocatable RPATH**: Defaults are set in **`CMakeLists.txt`** (`CMAKE_INSTALL_RPATH`, **`CMAKE_BUILD_RPATH`** (same list for the build tree), `CMAKE_SKIP_RPATH`, `CMAKE_INSTALL_RPATH_USE_LINK_PATH`). **`CMAKE_*_LINKER_FLAGS_INIT`** only adds **`--enable-new-dtags`** (RUNPATH behavior), not a second copy of **`$ORIGIN`**. On **GitHub Actions** (`GITHUB_ACTIONS=true`), **`CMAKE_SKIP_BUILD_RPATH`** applies when using **CMake 3.9+**, and **`CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH`** (strip implicit SDK paths on install) when using **CMake 3.16+**. The **`$ORIGIN`** relative entries resolve to the install prefix (`.../extras-<N>/bin` → `.../extras-<N>/lib`), so **`/opt/rocm/extras-<N>/lib` is not duplicated** in the list. Absolute paths add **`/opt/rocm/lib`**, **`/opt/rocm/lib/llvm/lib`** (older ROCm layouts), **`/opt/rocm/core-<ROCM_MAJOR>/lib`**, and **`/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib`** — equivalent to:
+**Relocatable RPATH**: The canonical list lives in **[`cmake_modules/RVSPackagedRpath.cmake`](../cmake_modules/RVSPackagedRpath.cmake)** (host triple detection via `amdclang++ --print-target-triple` is done there) and is applied via **`CMAKE_INSTALL_RPATH`** / **`CMAKE_BUILD_RPATH`** in **`CMakeLists.txt`**. **`CMAKE_*_LINKER_FLAGS_INIT`** only adds **`--enable-new-dtags`** (RUNPATH behavior). **Local dev builds** may also retain implicit **`$ROCM_PATH`** link-dir RUNPATH entries ( **`CMAKE_INSTALL_REMOVE_ENVIRONMENT_RPATH`** is set only when **`GITHUB_ACTIONS=true`** ).
+
+**Packaged artifacts** (DEB/RPM/TGZ): **`CPACK_PRE_BUILD_SCRIPTS`** runs **[`cmake_modules/cpack-patch-rpath.cmake.in`](../cmake_modules/cpack-patch-rpath.cmake.in)** before CPack seals the package. It uses **`patchelf`** to replace RUNPATH on every staged ELF with the canonical list (no build-machine SDK paths). Requires **`patchelf`** on the packaging host (`build_packages_local.sh` installs it).
+
+The **`$ORIGIN`** relative entries resolve to the install prefix (`.../extras-<N>/bin` → `.../extras-<N>/lib`). Absolute paths add **`/opt/rocm/lib`**, **`/opt/rocm/lib/llvm/lib`**, **`/opt/rocm/core-<ROCM_MAJOR>/lib`**, **`/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib`**, and per-host-triple **`libomp`** dirs when the triple is known — equivalent to:
 
 ```bash
-CMAKE_INSTALL_RPATH="$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-<ROCM_MAJOR>/lib:/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib"
+$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-<ROCM_MAJOR>/lib:/opt/rocm/core-<ROCM_MAJOR>/lib/llvm/lib
 ```
 
 **Automatic Version Management**: CMake reads the project version from `CMakeLists.txt` and CPack uses it for package naming automatically. The **patch version** is auto-computed at CMake configure time: `git describe --tags --match "v<major>.<minor>.*"` counts commits since the last matching `v` tag. For example, if the tag is `v1.3.0` and there have been 15 commits since, the package version becomes `1.3.15`. If no matching tag exists or git is unavailable, the patch defaults to `0` from `CMakeLists.txt`. This works for both CI builds and direct local `cmake` invocations.
@@ -608,10 +612,12 @@ cmake -B "$BUILD_DIR" \
 If binaries can't find libraries:
 
 ```bash
-# Check RPATH settings (replace 7 with your ROCm major version)
-readelf -d /opt/rocm/extras-7/bin/rvs | grep RPATH
+# Check RUNPATH on an installed package binary (replace 7 with your ROCm major version)
+readelf -d /opt/rocm/extras-7/bin/rvs | grep -E 'RUNPATH|RPATH'
+patchelf --print-rpath /opt/rocm/extras-7/bin/rvs
 
-# Should include: $ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-7/lib:/opt/rocm/core-7/lib/llvm/lib
+# Packaged binaries should only use $ORIGIN* and /opt/rocm/* entries (no build SDK paths).
+# Local build-tree binaries may still list $ROCM_PATH from the build host — that is expected.
 ```
 
 ### Missing Dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -983,6 +983,6 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/cpack-patch-rpath.cmake.in
   ${CMAKE_BINARY_DIR}/cpack-patch-rpath.cmake
   @ONLY)
-set(CPACK_PRE_BUILD_SCRIPTS ${CMAKE_BINARY_DIR}/cpack-patch-rpath.cmake)
+set(CPACK_PRE_BUILD_SCRIPTS "${CMAKE_BINARY_DIR}/cpack-patch-rpath.cmake")
 
 include (CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,59 +198,12 @@ set(CMAKE_INSTALL_PREFIX "/opt/rocm/extras-${ROCM_MAJOR_VERSION}" CACHE PATH "CM
 set(CPACK_PACKAGING_INSTALL_PREFIX "/opt/rocm/extras-${ROCM_MAJOR_VERSION}" CACHE PATH "Prefix used in built packages")
 list(APPEND CMAKE_PREFIX_PATH "${ROCM_PATH}")
 
-# libomp.so is installed under lib/llvm/lib/<host-triple>/ when ROCm LLVM is
-# built with LLVM_ENABLE_PER_TARGET_RUNTIME_DIR.
-find_program(RVS_ROCM_CLANG
-  NAMES amdclang++ clang++
-  HINTS "${ROCM_PATH}/bin" "${ROCM_PATH}/lib/llvm/bin" "/opt/rocm" "/opt/rocm/core-${ROCM_MAJOR_VERSION}"
-  PATH_SUFFIXES bin llvm/bin
-  NO_CACHE)
-set(RVS_LLVM_HOST_RUNTIME_DIR "")
-set(RVS_LLVM_HOST_RUNTIME_CORE_DIR "")
-if(RVS_ROCM_CLANG)
-  execute_process(
-    COMMAND "${RVS_ROCM_CLANG}" --print-target-triple
-    OUTPUT_VARIABLE RVS_HOST_TARGET_TRIPLE
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE _rvs_triple_rc
-    ERROR_QUIET)
-  if(_rvs_triple_rc EQUAL 0 AND RVS_HOST_TARGET_TRIPLE)
-    #FIXME Hardcoding /opt/rocm and /opt/rocm/core for now
-    set(RVS_LLVM_HOST_RUNTIME_DIR
-        "/opt/rocm/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}")
-    set(RVS_LLVM_HOST_RUNTIME_CORE_DIR
-        "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}")
-    message(STATUS "RVS LLVM host runtime dir (libomp): ${RVS_LLVM_HOST_RUNTIME_DIR}")
-  else()
-    message(WARNING
-      "Could not query --print-target-triple from ${RVS_ROCM_CLANG}; "
-      "libomp may not be found at runtime.")
-  endif()
-else()
-  message(WARNING
-    "No ROCm clang found under ${ROCM_PATH}; libomp per-target RPATH omitted.")
-endif()
-
-# RPATH (build tree + install): one list — avoids duplicating $ORIGIN paths that previously
-# appeared in both CMAKE_*_LINKER_FLAGS_INIT and CMAKE_INSTALL_RPATH.
+# RPATH (build tree + install): canonical list in cmake_modules/RVSPackagedRpath.cmake.
+# Packaged DEB/RPM/TGZ artifacts are normalized again via CPACK_PRE_BUILD_SCRIPTS.
 set(CMAKE_SKIP_RPATH FALSE CACHE BOOL "Skip RPATH for build targets")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE CACHE BOOL "Append link paths to install RPATH")
-set(_RVS_INSTALL_RPATH
-  "\$ORIGIN"
-  "\$ORIGIN/../lib"
-  "\$ORIGIN/../lib/rvs"
-  "/opt/rocm/lib"
-  "/opt/rocm/lib/llvm/lib"
-  "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib"
-  "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib")
-if(RVS_LLVM_HOST_RUNTIME_DIR)
-  if(EXISTS RVS_LLVM_HOST_RUNTIME_DIR)
-    list(APPEND _RVS_INSTALL_RPATH "${RVS_LLVM_HOST_RUNTIME_DIR}")
-  endif()
-  if(EXISTS RVS_LLVM_HOST_RUNTIME_CORE_DIR)
-    list(APPEND _RVS_INSTALL_RPATH "${RVS_LLVM_HOST_RUNTIME_CORE_DIR}")
-  endif()
-endif()
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/RVSPackagedRpath.cmake)
+rvs_get_packaged_rpath_list(_RVS_INSTALL_RPATH)
 set(CMAKE_INSTALL_RPATH "${_RVS_INSTALL_RPATH}"
   CACHE STRING "RPATH for installed RVS binaries and modules")
 set(CMAKE_BUILD_RPATH "${CMAKE_INSTALL_RPATH}")
@@ -1023,5 +976,13 @@ install(FILES
 set(CPACK_RPM_PACKAGE_AUTOREQ 0)
 
 configure_pkg( ${CPACK_PACKAGE_NAME} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL} )
+
+# Normalize RUNPATH on staged ELF before DEB/RPM/TGZ (strips build-machine SDK paths).
+rvs_get_packaged_rpath_colon(RVS_PACKAGED_RPATH_COLON)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/cpack-patch-rpath.cmake.in
+  ${CMAKE_BINARY_DIR}/cpack-patch-rpath.cmake
+  @ONLY)
+set(CPACK_PRE_BUILD_SCRIPTS ${CMAKE_BINARY_DIR}/cpack-patch-rpath.cmake)
 
 include (CPack)

--- a/build_packages_local.sh
+++ b/build_packages_local.sh
@@ -490,6 +490,7 @@ check_and_install_dependencies() {
     command -v tar >/dev/null 2>&1 || MISSING_TOOLS+=("tar")
     command -v doxygen >/dev/null 2>&1 || MISSING_TOOLS+=("doxygen")
     command -v python3 >/dev/null 2>&1 || MISSING_TOOLS+=("python3")
+    command -v patchelf >/dev/null 2>&1 || MISSING_TOOLS+=("patchelf")
 
     # Check for library dependencies (platform-specific)
     MISSING_LIBS=()
@@ -538,7 +539,8 @@ check_and_install_dependencies() {
                 libyaml-cpp-dev \
                 rpm \
                 python3 \
-                libnuma-dev
+                libnuma-dev \
+                patchelf
         elif [[ "$OS" =~ ^(centos|rhel|rocky|almalinux|amzn)$ ]]; then
             print_info "Installing dependencies for CentOS/RHEL/Rocky/AlmaLinux..."
 
@@ -583,6 +585,7 @@ check_and_install_dependencies() {
                 rpm-build \
                 python3 \
                 numactl-devel \
+                patchelf \
                 || print_warning "Some packages may already be installed"
 
             # Install a gcc-toolset with C++20 <barrier> support (requires GCC >= 11)
@@ -641,6 +644,7 @@ check_and_install_dependencies() {
                 libnuma-devel \
                 rpm \
                 rpm-build \
+                patchelf \
                 || print_warning "Some packages may already be installed"
         else
             print_error "Unsupported OS: $OS"
@@ -660,6 +664,7 @@ check_and_install_dependencies() {
             echo "  - libpci-dev (or pciutils-devel)"
             echo "  - libyaml-cpp-dev (or yaml-cpp-devel)"
             echo "  - libnuma-dev (Ubuntu), numactl-devel (RHEL/CentOS), or libnuma-devel (SLES)"
+            echo "  - patchelf (CPack RUNPATH normalization for DEB/RPM/TGZ)"
             echo "  - rpm-build tools"
             exit 1
         fi

--- a/cmake_modules/RVSPackagedRpath.cmake
+++ b/cmake_modules/RVSPackagedRpath.cmake
@@ -1,0 +1,56 @@
+# Canonical relocatable RUNPATH for packaged RVS artifacts (DEB/RPM/TGZ).
+# Used by CMAKE_INSTALL_RPATH and cpack-patch-rpath.cmake (via configure_file).
+#
+# Expects ROCM_PATH and ROCM_MAJOR_VERSION in the including scope.
+
+# libomp.so lives under lib/llvm/lib/<host-triple>/ when ROCm LLVM uses
+# LLVM_ENABLE_PER_TARGET_RUNTIME_DIR.
+set(RVS_HOST_TARGET_TRIPLE "")
+find_program(RVS_ROCM_CLANG
+  NAMES amdclang++ clang++
+  HINTS "${ROCM_PATH}/bin" "${ROCM_PATH}/lib/llvm/bin" "/opt/rocm" "/opt/rocm/core-${ROCM_MAJOR_VERSION}"
+  PATH_SUFFIXES bin llvm/bin
+  NO_CACHE)
+if(RVS_ROCM_CLANG)
+  execute_process(
+    COMMAND "${RVS_ROCM_CLANG}" --print-target-triple
+    OUTPUT_VARIABLE RVS_HOST_TARGET_TRIPLE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _rvs_triple_rc
+    ERROR_QUIET)
+  if(_rvs_triple_rc EQUAL 0 AND RVS_HOST_TARGET_TRIPLE)
+    message(STATUS
+      "RVS LLVM host runtime dir (libomp): /opt/rocm/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}")
+  else()
+    message(WARNING
+      "Could not query --print-target-triple from ${RVS_ROCM_CLANG}; "
+      "libomp may not be found at runtime.")
+    set(RVS_HOST_TARGET_TRIPLE "")
+  endif()
+else()
+  message(WARNING
+    "No ROCm clang found under ${ROCM_PATH}; libomp per-target RPATH omitted.")
+endif()
+
+function(rvs_get_packaged_rpath_list out_var)
+  set(_rpath
+    "\$ORIGIN"
+    "\$ORIGIN/../lib"
+    "\$ORIGIN/../lib/rvs"
+    "/opt/rocm/lib"
+    "/opt/rocm/lib/llvm/lib"
+    "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib"
+    "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib")
+  if(RVS_HOST_TARGET_TRIPLE)
+    list(APPEND _rpath
+      "/opt/rocm/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}"
+      "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}")
+  endif()
+  set(${out_var} ${_rpath} PARENT_SCOPE)
+endfunction()
+
+function(rvs_get_packaged_rpath_colon out_var)
+  rvs_get_packaged_rpath_list(_list)
+  string(JOIN ":" _colon ${_list})
+  set(${out_var} "${_colon}" PARENT_SCOPE)
+endfunction()

--- a/cmake_modules/RVSPackagedRpath.cmake
+++ b/cmake_modules/RVSPackagedRpath.cmake
@@ -37,14 +37,14 @@ function(rvs_get_packaged_rpath_list out_var)
     "\$ORIGIN"
     "\$ORIGIN/../lib"
     "\$ORIGIN/../lib/rvs"
-    "/opt/rocm/lib"
-    "/opt/rocm/lib/llvm/lib"
     "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib"
-    "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib")
+    "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib"
+    "/opt/rocm/lib"
+    "/opt/rocm/lib/llvm/lib")
   if(RVS_HOST_TARGET_TRIPLE)
     list(APPEND _rpath
-      "/opt/rocm/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}"
-      "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}")
+      "/opt/rocm/core-${ROCM_MAJOR_VERSION}/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}"
+      "/opt/rocm/lib/llvm/lib/${RVS_HOST_TARGET_TRIPLE}")
   endif()
   set(${out_var} ${_rpath} PARENT_SCOPE)
 endfunction()

--- a/cmake_modules/cpack-patch-rpath.cmake.in
+++ b/cmake_modules/cpack-patch-rpath.cmake.in
@@ -18,10 +18,12 @@ foreach(_candidate IN LISTS _candidates)
   if(NOT EXISTS "${_candidate}")
     continue()
   endif()
+  # Patch versioned ELF .so files only; skip symlinks (libfoo.so -> libfoo.so.0).
+  # get_filename_component REALPATH needs CMake 3.20+; symlinks inherit the target RUNPATH.
   if(IS_SYMLINK "${_candidate}")
-    get_filename_component(_candidate REALPATH "${_candidate}")
+    continue()
   endif()
-  if(NOT EXISTS "${_candidate}" OR IS_DIRECTORY "${_candidate}")
+  if(IS_DIRECTORY "${_candidate}")
     continue()
   endif()
 

--- a/cmake_modules/cpack-patch-rpath.cmake.in
+++ b/cmake_modules/cpack-patch-rpath.cmake.in
@@ -1,0 +1,46 @@
+# CPack pre-build script: normalize RUNPATH on staged ELF files before DEB/RPM/TGZ.
+# Generated at configure time — do not edit.
+# Local cmake --build trees are not modified; only CPack staging is patched.
+
+find_program(PATCHELF_EXECUTABLE patchelf REQUIRED)
+
+if(NOT DEFINED CPACK_TOPLEVEL_DIRECTORY OR NOT CPACK_TOPLEVEL_DIRECTORY)
+  message(FATAL_ERROR "cpack-patch-rpath: CPACK_TOPLEVEL_DIRECTORY is not set")
+endif()
+
+set(_rvs_rpath "@RVS_PACKAGED_RPATH_COLON@")
+set(_patched 0)
+set(_skipped 0)
+
+file(GLOB_RECURSE _candidates LIST_DIRECTORIES false "${CPACK_TOPLEVEL_DIRECTORY}/*")
+
+foreach(_candidate IN LISTS _candidates)
+  if(NOT EXISTS "${_candidate}")
+    continue()
+  endif()
+  if(IS_SYMLINK "${_candidate}")
+    get_filename_component(_candidate REALPATH "${_candidate}")
+  endif()
+  if(NOT EXISTS "${_candidate}" OR IS_DIRECTORY "${_candidate}")
+    continue()
+  endif()
+
+  file(READ "${_candidate}" _magic OFFSET 0 LIMIT 4 HEX)
+  if(NOT _magic STREQUAL "7f454c46")
+    continue()
+  endif()
+
+  execute_process(
+    COMMAND "${PATCHELF_EXECUTABLE}" --set-rpath "${_rvs_rpath}" "${_candidate}"
+    RESULT_VARIABLE _patch_rc
+    ERROR_VARIABLE _patch_err)
+  if(_patch_rc EQUAL 0)
+    math(EXPR _patched "${_patched} + 1")
+    message(STATUS "cpack-patch-rpath: ${_candidate}")
+  else()
+    math(EXPR _skipped "${_skipped} + 1")
+    message(WARNING "cpack-patch-rpath: failed on ${_candidate}: ${_patch_err}")
+  endif()
+endforeach()
+
+message(STATUS "cpack-patch-rpath: patched ${_patched} ELF file(s), ${_skipped} failure(s)")


### PR DESCRIPTION
## Motivation

Currently build location of ROCM/LLVM libraries are getting added to RPATH of RVS binaries and libraries. With ROCm getting installed in "/opt/rocm/core-[rocm-major]" only keep those associated with installed ROCm. Any ROCm install outside of this need to use ldconfig or LD_LIBRARY_PATH to load correct ROCm libraries

## Test Result

readelf -d build/_CPack_Packages/Linux/DEB/amdrocm10-rvs-1.7.42-r1001.20260909-Linux/opt/rocm/extras-10/bin/rvs

Dynamic section at offset 0x3f900 contains 41 entries:
  Tag        Type                         Name/Value
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:$ORIGIN/../lib:$ORIGIN/../lib/rvs:/opt/rocm/core-10/lib:/opt/rocm/core-10/lib/llvm/lib:/opt/rocm/lib:/opt/rocm/lib/llvm/lib:/opt/rocm/core-10/lib/llvm/lib/x86_64-unknown-linux-gnu:/opt/rocm/lib/llvm/lib/x86_64-unknown-linux-gnu]

